### PR TITLE
#61 Fix: ResponseBody에 userUUID, AT값 들어가지 않게 수정

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/service/AuthService.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/AuthService.java
@@ -125,10 +125,8 @@ public class AuthService {
         addAccessTokenHeaders(response, newAccessToken, uuid);
 
         // 7) 응답 바디 반환
-        Map<String, String> data = Map.of(
-                "accessToken", newAccessToken,
-                "userUUID", uuid
-        );
+        Map<String, String> data = new HashMap<>();
+        data.put("로그인 상태", "성공");
         return ApiResponseDTO.success(SuccessCode.AUTH_200_007, data);
     }
 


### PR DESCRIPTION
## 연관 이슈
> #61 #62 #63 

## 작업 요약
> ResponseBody에 userUUID, AT값 들어가지 않게 수정

## 작업 상세 설명
> ResponseBody에 userUUID, AT값이 나왔는데 나오지 않게끔 수정

## 기타
> 없음
