### PR TITLE
#61 Feat: jwt필터에 블랙리스트 체크 로직 추가

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gyeongditor/storyfield/jwt/JwtAuthenticationFilter.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gyeongditor.storyfield.Entity.CustomUserDetails;
 import com.gyeongditor.storyfield.dto.ApiResponseDTO;
 import com.gyeongditor.storyfield.exception.CustomException;
+import com.gyeongditor.storyfield.repository.JwtTokenRedisRepository;
 import com.gyeongditor.storyfield.response.ErrorCode;
 import com.gyeongditor.storyfield.service.CustomUserDetailsService;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,6 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JwtTokenRedisRepository jwtTokenRedisRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -35,7 +38,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             if (accessToken != null) {
+                // 1. 서명/만료 검증
                 jwtTokenProvider.validateOrThrow(accessToken);
+
+                // 2. 블랙리스트 확인
+                Claims claims = jwtTokenProvider.parseClaims(accessToken);
+                String jti = claims.getId();
+                if (jwtTokenRedisRepository.isTokenBlacklisted(jti)) {
+                    throw new CustomException(ErrorCode.AUTH_401_008, "이미 로그아웃된 액세스 토큰입니다.");
+                }
+
+                // 3. 정상 인증 처리
                 authenticateWithToken(accessToken, request);
             }
 
@@ -47,6 +60,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             writeJsonError(response, ErrorCode.AUTH_401_004, "유효하지 않은 인증 토큰입니다.");
         }
     }
+
 
     private void authenticateWithToken(String token, HttpServletRequest request) {
         String email = jwtTokenProvider.getEmail(token);

--- a/src/main/java/com/gyeongditor/storyfield/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/gyeongditor/storyfield/jwt/JwtTokenProvider.java
@@ -136,7 +136,7 @@ public class JwtTokenProvider {
     /**
      * 토큰 파싱
      */
-    private Claims parseClaims(String token) {
+    public Claims parseClaims(String token) {
         try {
             return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
         } catch (Exception e) {


### PR DESCRIPTION
## 연관 이슈

#61 #62 #63 
## 작업 요약
필터에서 블랙리스트 토큰 검증 추가

## 작업 상세 설명
- JwtAuthenticationFilter에 블랙리스트 확인 로직 추가
- 로그아웃된 AccessToken 요청 시 권한 에러 반환

## 기타
- 기존 validateOrThrow 로직은 그대로 유지
