### PR TITLE
65 feature 파일 및 context 저장조회 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,6 @@ dependencies {
     implementation 'io.github.resilience4j:resilience4j-spring-boot3'
     implementation 'io.github.resilience4j:resilience4j-reactor'
 
-    // Observability
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
     // Jackson JSR310 (LocalDateTime 지원)
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'

--- a/src/main/java/com/gyeongditor/storyfield/dto/ApiResponseDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/ApiResponseDTO.java
@@ -4,9 +4,11 @@ import com.gyeongditor.storyfield.response.ErrorCode;
 import com.gyeongditor.storyfield.response.SuccessCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor  // ✅ Jackson이 필요로 함
+@AllArgsConstructor // ✅ 생성자 기반 주입도 가능
 public class ApiResponseDTO<T> {
     private int status;        // HTTP 상태 코드
     private String code;       // 내부 커스텀 코드

--- a/src/main/java/com/gyeongditor/storyfield/dto/Story/StoryThumbnailResponseDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/Story/StoryThumbnailResponseDTO.java
@@ -19,6 +19,6 @@ public class StoryThumbnailResponseDTO {
     @Schema(description = "스토리 제목", example = "용감한 병아리의 모험")
     private String storyTitle;
 
-    @Schema(description = "썸네일 이미지 URL (4번 페이지 기준)", example = "https://example.com/image4.png")
+    @Schema(description = "썸네일 이미지 URL (3번 페이지 기준)", example = "https://example.com/image3.png")
     private String thumbnailUrl;
 }

--- a/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/LoginDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/LoginDTO.java
@@ -5,11 +5,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
+@NoArgsConstructor(force = true)  // ✅ Jackson이 필요로 함
+@AllArgsConstructor // ✅ 생성자 기반 주입도 가능
 @Schema(description = "로그인 요청 DTO")
 public class LoginDTO {
     @Schema(description = "이메일 주소", example = "user@example.com")

--- a/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/LoginDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/LoginDTO.java
@@ -14,11 +14,11 @@ import lombok.Setter;
 @AllArgsConstructor // ✅ 생성자 기반 주입도 가능
 @Schema(description = "로그인 요청 DTO")
 public class LoginDTO {
-    @Schema(description = "이메일 주소", example = "user@example.com")
+    @Schema(description = "이메일 주소", example = "newuser@example.com")
     @NotBlank(message = "이메일을 입력해주세요")
     private final String email;
 
-    @Schema(description = "비밀번호", example = "Password123!")
+    @Schema(description = "비밀번호", example = "SignUp123!")
     @NotBlank(message = "비밀번호를 입력해주세요")
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,16}$",
             message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함하여 8~16자여야 합니다")

--- a/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/ResponseDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/ResponseDTO.java
@@ -3,9 +3,11 @@ package com.gyeongditor.storyfield.dto.UserDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor  // ✅ Jackson이 필요로 함
+@AllArgsConstructor // ✅ 생성자 기반 주입도 가능
 @Schema(description = "응답 DTO")
 public class ResponseDTO {
     private int statusCode;

--- a/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/SignUpDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/SignUpDTO.java
@@ -7,8 +7,8 @@ import jakarta.validation.constraints.Pattern;
 
 @Getter
 @Setter
-@AllArgsConstructor
-@Schema(description = "회원가입 요청 DTO")
+@NoArgsConstructor(force = true)  // ✅ Jackson이 필요로 함
+@AllArgsConstructor // ✅ 생성자 기반 주입도 가능@Schema(description = "회원가입 요청 DTO")
 public class SignUpDTO {
 
     @Schema(description = "회원가입 이메일 주소", example = "newuser@example.com")

--- a/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/UpdateUserDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/UpdateUserDTO.java
@@ -11,8 +11,15 @@ import lombok.*;
 @NoArgsConstructor
 @Schema(description = "회원 정보 수정 DTO")
 public class UpdateUserDTO {
+
+    @Schema(description = "사용자 이메일 (변경 시 사용 가능)", example = "newuser@example.com")
     private String email;
+
+    @Schema(description = "변경할 비밀번호 (선택사항)",
+            example = "NewPassword123!",
+            nullable = true)
     private String password;
+
     @Schema(description = "변경할 사용자 이름", example = "길동이")
     @NotBlank(message = "이름을 입력해주세요")
     private String username;

--- a/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/UserDTO/UserResponseDTO.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Schema(description = "유저 응답 DTO")
 public class UserResponseDTO {
 
-    @Schema(description = "사용자 이메일", example = "user@example.com")
+    @Schema(description = "사용자 이메일", example = "newuser@example.com")
     private String email;
     @Schema(description = "사용자 이름", example = "홍길동")
     private String username;


### PR DESCRIPTION
## 연관 이슈
> #65 

## 작업 요약
> DTO 직렬화 오류 해결을 위해 기본 생성자 추가, 불필요한 Zipkin 의존성 제거, Swagger 요청 예제 개선

## 작업 상세 설명
> - `LoginDTO`, `SignUpDTO` 등 Jackson 직렬화를 위해 **기본 생성자(@NoArgsConstructor)** 추가  
> - 사용하지 않는 **Zipkin 의존성** 제거하여 불필요한 연결 시도 및 에러 로그 발생 문제 해결  
> - `UpdateUserDTO` 및 요청 DTO에 **Swagger 예제(@Schema)** 보강하여 API 문서 가독성 및 명확성 개선  

## 기타
> - 추후 Observability(분산 트레이싱) 필요 시, Zipkin 대신 OTEL(OpenTelemetry) 기반 도입 검토 가능  