### PR TITLE
#65 Feature: 파일 및 context 저장·조회 API 추가 및 StoryService 개선

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/Entity/Story.java
+++ b/src/main/java/com/gyeongditor/storyfield/Entity/Story.java
@@ -23,8 +23,13 @@ public class Story {
     @JoinColumn(name = "user_id", referencedColumnName = "user_id")
     private User user;
 
+    @Column(nullable = false)
     private String storyTitle;
 
+    @Column(nullable = false)
+    private String thumbnailFileName;
+
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;

--- a/src/main/java/com/gyeongditor/storyfield/Entity/StoryPage.java
+++ b/src/main/java/com/gyeongditor/storyfield/Entity/StoryPage.java
@@ -19,9 +19,10 @@ public class StoryPage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private int pageNumber;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
     // presignedUrl 대신 S3에 업로드된 실제 파일 이름만 저장

--- a/src/main/java/com/gyeongditor/storyfield/Entity/User.java
+++ b/src/main/java/com/gyeongditor/storyfield/Entity/User.java
@@ -35,6 +35,7 @@ public class User {
     private String username;
 
     @CreationTimestamp // INSERT 쿼리가 발생할 때, 현재 시간을 자동으로 저장
+    @Column(nullable = false)
     private LocalDateTime created_at; // 회원가입한 시간
 
     @UpdateTimestamp // UPDATE 쿼리가 발생할 때, 현재 시간을 자동으로 저장

--- a/src/main/java/com/gyeongditor/storyfield/dto/Story/SaveStoryDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/Story/SaveStoryDTO.java
@@ -14,8 +14,12 @@ import java.util.List;
 @AllArgsConstructor
 @Schema(description = "스토리 저장 요청 DTO")
 public class SaveStoryDTO {
+
     @Schema(description = "스토리 제목", example = "용감한 병아리의 모험")
     private String storyTitle;
+
+    @Schema(description = "스토리 썸네일 파일명", example = "thumb_1234.png")
+    private String thumbnailFileName;  // ✅ 추가
 
     @Schema(description = "스토리 페이지 리스트")
     private List<StoryPageDTO> pages;

--- a/src/main/java/com/gyeongditor/storyfield/dto/Story/StoryPageDTO.java
+++ b/src/main/java/com/gyeongditor/storyfield/dto/Story/StoryPageDTO.java
@@ -19,4 +19,7 @@ public class StoryPageDTO {
 
     @Schema(description = "이미지 파일명", example = "xxx.png")
     private String imageFileName;
+
+    @Schema(description = "썸네일 파일명", example = "thumb_page_1.png")
+    private String thumbnailFileName;  // ✅ 새 필드
 }

--- a/src/main/java/com/gyeongditor/storyfield/handler/GlobalResponseHandler.java
+++ b/src/main/java/com/gyeongditor/storyfield/handler/GlobalResponseHandler.java
@@ -46,7 +46,7 @@ public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
     private final BusinessErrorMapper businessErrorMapper;
     private final FallbackErrorMapper fallbackErrorMapper;
 
-    // ====== 성공 응답 래핑 ======
+    // 성공 응답 래핑
     @Override
     public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
         // ResponseEntity는 제외
@@ -95,7 +95,7 @@ public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
         return ApiResponseDTO.success(success, body);
     }
 
-    // ====== 에러 응답 (중략: 이전에 분리해둔 매퍼 기반 처리 그대로 유지) ======
+    // 에러 응답 (중략: 이전에 분리해둔 매퍼 기반 처리 그대로 유지)
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponseDTO<Object>> onCustom(CustomException ex) {

--- a/src/main/java/com/gyeongditor/storyfield/handler/mapper/StoryErrorMapper.java
+++ b/src/main/java/com/gyeongditor/storyfield/handler/mapper/StoryErrorMapper.java
@@ -1,0 +1,34 @@
+package com.gyeongditor.storyfield.handler.mapper;
+
+import com.gyeongditor.storyfield.response.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+public class StoryErrorMapper {
+
+    private static final Map<Class<? extends Exception>, MappedError> MAPPINGS = new LinkedHashMap<>();
+
+    static {
+        // IO 계열
+        MAPPINGS.put(IOException.class,
+                new MappedError(ErrorCode.FILE_500_001, "파일 처리 중 오류가 발생했습니다."));
+
+        // 잘못된 요청 (ex: 페이지/파일 불일치)
+        MAPPINGS.put(IllegalArgumentException.class,
+                new MappedError(ErrorCode.STORY_400_001, "스토리 요청 데이터가 유효하지 않습니다."));
+    }
+
+    public MappedError map(Exception ex) {
+        Class<?> exClass = ex.getClass();
+        for (var entry : MAPPINGS.entrySet()) {
+            if (entry.getKey().isAssignableFrom(exClass)) {
+                return entry.getValue();
+            }
+        }
+        return new MappedError(ErrorCode.ETC_520_001, "알 수 없는 스토리 처리 오류");
+    }
+}

--- a/src/main/java/com/gyeongditor/storyfield/handler/mapper/SuccessCodeMapper.java
+++ b/src/main/java/com/gyeongditor/storyfield/handler/mapper/SuccessCodeMapper.java
@@ -19,14 +19,14 @@ public class SuccessCodeMapper {
     private final Map<BiFunction<String, HttpMethod, Boolean>, SuccessCode> rules = new LinkedHashMap<>();
 
     public SuccessCodeMapper() {
-        // ===== 사용자 관련 =====
+        // 사용자 관련
         rule((p, m) -> m == HttpMethod.POST   && p.matches("^/users/signup/?$"),              SuccessCode.USER_201_001); // 회원가입
         rule((p, m) -> m == HttpMethod.GET    && p.matches("^/users/me/?$"),        SuccessCode.USER_200_001); // 회원 조회
         rule((p, m) -> (m == HttpMethod.PUT || m == HttpMethod.PATCH) && p.matches("^/users/me+/?$"), SuccessCode.USER_200_002); // 회원 수정
         rule((p, m) -> m == HttpMethod.POST   && p.matches("^/users/verify/?$"), SuccessCode.USER_200_003); // 이메일 인증 완료
         rule((p, m) -> m == HttpMethod.DELETE && p.matches("^/users/me/[^/]+/?$"),        SuccessCode.USER_204_001); // 회원 삭제
 
-        // ===== 인증/Auth =====
+        // 인증/Auth
         rule((p, m) -> m == HttpMethod.POST   && p.matches("^/auth/login/?$"),         SuccessCode.AUTH_200_001); // 로그인
         rule((p, m) -> m == HttpMethod.POST   && p.matches("^/auth/logout/?$"),        SuccessCode.AUTH_200_002); // 로그아웃
         rule((p, m) -> m == HttpMethod.GET    && p.matches("^/auth/me/?$"),            SuccessCode.AUTH_200_003); // 사용자 정보 로드
@@ -34,21 +34,21 @@ public class SuccessCodeMapper {
         rule((p, m) -> m == HttpMethod.POST   && p.matches("^/auth/login/failed/?$"),  SuccessCode.AUTH_200_006); // 실패 횟수 업데이트(예시)
         rule((p, m) -> m == HttpMethod.POST   && p.matches("^/auth/login/reset/?$"),   SuccessCode.AUTH_200_005); // 실패 횟수 초기화(예시)
 
-        // ===== 메일 ===== path 미사용
+        // 메일 path 미사용
 //        rule((p, m) -> m == HttpMethod.POST   && p.matches("^/mail/verification/?$"),  SuccessCode.MAIL_200_001); // 인증 메일 전송
 //        rule((p, m) -> m == HttpMethod.POST   && p.matches("^/mail/verify/?$"),        SuccessCode.MAIL_200_002); // 이메일 인증 완료
 
-        // ===== 스토리 =====
+        // 스토리
         rule((p, m) -> m == HttpMethod.POST   && p.matches("^/stories/?$"),            SuccessCode.STORY_201_001); // 스토리 생성
         rule((p, m) -> m == HttpMethod.GET    && p.matches("^/stories/[^/]+/pages/?$"),      SuccessCode.STORY_200_001); // 스토리 페이지 조회
         rule((p, m) -> m == HttpMethod.GET    && p.matches("^/stories/thumbnails/?$"),            SuccessCode.STORY_200_002); // 메인 목록 조회
         rule((p, m) -> m == HttpMethod.DELETE && p.matches("^/stories/[^/]+/?$"),      SuccessCode.STORY_204_001); // 스토리 삭제
 
-        // ===== OAuth2 ===== path 미사용
+        // OAuth2 path 미사용
 //        rule((p, m) -> m == HttpMethod.GET    && p.matches("^/login/oauth2/code/.*$"),     SuccessCode.OAUTH2_200_001); // OAuth2 로그인 콜백 성공
 //        rule((p, m) -> m == HttpMethod.POST   && p.matches("^/oauth2/users/?$"),       SuccessCode.OAUTH2_201_001); // 신규 OAuth2 사용자 생성
 
-        // ===== 파일 =====
+        // 파일
         rule((p, m) -> m == HttpMethod.POST   && p.matches("^/images/?$"),       SuccessCode.FILE_200_001); // 파일 업로드
         rule((p, m) -> m == HttpMethod.GET    && p.matches("^/images/presign/?$"),      SuccessCode.FILE_200_002); // Presigned URL
         rule((p, m) -> m == HttpMethod.GET    && p.matches("^/images/[^/]+/?$"),          SuccessCode.FILE_200_003);   // 파일 URL 조회

--- a/src/main/java/com/gyeongditor/storyfield/response/ErrorCode.java
+++ b/src/main/java/com/gyeongditor/storyfield/response/ErrorCode.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
 
-    // ===================== 1. 인증/인가 (Authentication & Authorization) =====================
+    // 인증/인가 (Authentication & Authorization)
     AUTH_401_001(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "로그인 필요"),
     AUTH_401_002(HttpStatus.UNAUTHORIZED, "AUTH_401_002", "세션 만료"),
     AUTH_401_003(HttpStatus.UNAUTHORIZED, "AUTH_401_003", "토큰 없음"),
@@ -15,7 +15,7 @@ public enum ErrorCode {
     AUTH_403_003(HttpStatus.FORBIDDEN, "AUTH_403_003", "해당 기능은 특정 등급 이상만 가능"),
     AUTH_401_006(HttpStatus.UNAUTHORIZED, "AUTH_401_006", "OAuth 인증 실패"),
 
-    // ===================== 2. 사용자 입력/요청 오류 (Client Errors) =====================
+    // 사용자 입력/요청 오류 (Client Errors)
     REQ_400_001(HttpStatus.BAD_REQUEST, "REQ_400_001", "잘못된 요청 형식"),
     REQ_400_002(HttpStatus.BAD_REQUEST, "REQ_400_002", "필수 입력값 누락"),
     REQ_400_003(HttpStatus.BAD_REQUEST, "REQ_400_003", "데이터 형식 오류 (숫자 → 문자열)"),
@@ -25,7 +25,7 @@ public enum ErrorCode {
     REQ_413_001(HttpStatus.PAYLOAD_TOO_LARGE, "REQ_413_001", "허용된 요청 크기 초과"),
     REQ_429_001(HttpStatus.TOO_MANY_REQUESTS, "REQ_429_001", "요청 횟수 초과 (Rate Limit)"),
 
-    // ===================== 3. 회원/계정 관련 (Account & User Management) =====================
+    // 회원/계정 관련 (Account & User Management)
     USER_409_001(HttpStatus.CONFLICT, "USER_409_001", "중복된 이메일"),
     USER_409_002(HttpStatus.CONFLICT, "USER_409_002", "중복된 닉네임"),
     USER_404_001(HttpStatus.NOT_FOUND, "USER_404_001", "존재하지 않는 계정"),
@@ -37,7 +37,7 @@ public enum ErrorCode {
     USER_423_002(HttpStatus.LOCKED, "USER_423_002", "계정이 잠금되었습니다. 잠시 후 다시 시도해주세요."),
     USER_403_003(HttpStatus.FORBIDDEN, "USER_403_003", "계정이 활성화되지 않았습니다. 이메일 인증을 완료해주세요."),
 
-    // ===================== 4. 인증/Auth 관련 =====================
+    // 인증/Auth 관련
     AUTH_401_007(HttpStatus.UNAUTHORIZED, "AUTH_401_007", "OAuth2 사용자 정보를 가져올 수 없습니다."),
     AUTH_401_008(HttpStatus.UNAUTHORIZED, "AUTH_401_008", "지원하지 않는 OAuth2 Provider입니다."),
     AUTH_401_009(HttpStatus.UNAUTHORIZED, "AUTH_401_009", "아이디 또는 비밀번호가 올바르지 않습니다."),
@@ -47,20 +47,15 @@ public enum ErrorCode {
     AUTH_401_013(HttpStatus.UNAUTHORIZED, "AUTH_401_013", "세션이 만료되었습니다."),
     AUTH_500_001(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_500_001", "OAuth2 사용자 정보 처리 중 오류가 발생했습니다."),
 
-    // ===================== 5. 리소스 관련 (Resource Errors) =====================
+    // 리소스 관련 (Resource Errors)
     RES_404_001(HttpStatus.NOT_FOUND, "RES_404_001", "존재하지 않는 데이터"),
     RES_410_001(HttpStatus.GONE, "RES_410_001", "삭제된 데이터 접근"),
     RES_409_001(HttpStatus.CONFLICT, "RES_409_001", "이미 존재하는 데이터"),
     RES_409_002(HttpStatus.CONFLICT, "RES_409_002", "동시성 충돌 (다른 사용자가 이미 수정)"),
     RES_403_001(HttpStatus.FORBIDDEN, "RES_403_001", "데이터 조회 제한 (비공개, 제한 계정)"),
-
-    // ===================== 6. 비즈니스 로직 오류 (Business Logic) =====================
-    STORY_404_001(HttpStatus.NOT_FOUND, "STORY_404_001", "스토리가 존재하지 않습니다."),
-    STORY_403_001(HttpStatus.FORBIDDEN, "STORY_403_001", "해당 스토리에 대한 삭제 권한이 없습니다."),
-
     MAIL_500_001(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL_500_001", "메일 전송 중 오류가 발생했습니다."),
 
-    // ===================== 7. 서버/인프라 오류 (Server Errors) =====================
+    // 서버/인프라 오류 (Server Errors)
     SERVER_500_001(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_500_001", "내부 서버 오류"),
     SERVER_500_002(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_500_002", "DB 연결 실패"),
     SERVER_502_001(HttpStatus.BAD_GATEWAY, "SERVER_502_001", "외부 API 통신 오류"),
@@ -68,26 +63,27 @@ public enum ErrorCode {
     SERVER_504_001(HttpStatus.GATEWAY_TIMEOUT, "SERVER_504_001", "작업 타임아웃"),
     SERVER_502_002(HttpStatus.BAD_GATEWAY, "SERVER_502_002", "캐시 서버 오류"),
 
-    // ===================== 8. 파일/업로드 관련 (File & Upload) =====================
-    FILE_500_001(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_001", "파일 업로드 중 오류 발생"),
-    FILE_500_002(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_002", "Presigned URL 생성 실패"),
-    FILE_500_003(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_003", "파일 URL 조회 실패"),
-    FILE_500_004(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_004", "파일 삭제 실패"),
-
-
-    // ===================== 9. 정책/보안 관련 (Policy & Security) =====================
+    // 정책/보안 관련 (Policy & Security)
     SEC_403_001(HttpStatus.FORBIDDEN, "SEC_403_001", "비정상 요청 탐지"),
     SEC_403_002(HttpStatus.FORBIDDEN, "SEC_403_002", "CSRF 검증 실패"),
     SEC_403_003(HttpStatus.FORBIDDEN, "SEC_403_003", "보안 정책 위반 (IP 차단)"),
     SEC_403_004(HttpStatus.FORBIDDEN, "SEC_403_004", "관리자 승인 대기 상태"),
     SEC_401_001(HttpStatus.UNAUTHORIZED, "SEC_401_001", "이중 인증(2FA) 미완료"),
 
-    // ===================== 10. 기타 (Etc) =====================
+    // 스토리/파일 관련
+    STORY_400_001(HttpStatus.BAD_REQUEST, "STORY_400_001", "스토리 요청 데이터가 잘못되었습니다."),
+    STORY_404_001(HttpStatus.NOT_FOUND, "STORY_404_001", "스토리를 찾을 수 없습니다."),
+    STORY_403_001(HttpStatus.FORBIDDEN, "STORY_403_001", "본인 스토리만 수정/삭제할 수 있습니다."),
+    FILE_500_001(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_001", "파일 업로드 중 오류가 발생했습니다."),
+    FILE_500_002(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_002", "파일 삭제 중 오류가 발생했습니다."),
+    FILE_500_003(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_003", "파일 URL 조회 실패"),
+    FILE_500_004(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_500_004", "파일 삭제 실패"),
+
+    // 기타 (Etc)
     ETC_520_001(HttpStatus.INTERNAL_SERVER_ERROR, "ETC_520_001", "알 수 없는 오류"),
     ETC_503_001(HttpStatus.SERVICE_UNAVAILABLE, "ETC_503_001", "서비스 점검 중"),
     ETC_426_001(HttpStatus.UPGRADE_REQUIRED, "ETC_426_001", "지원하지 않는 버전");
 
-    // ===================== Fields =====================
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/gyeongditor/storyfield/service/UserService.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/UserService.java
@@ -110,7 +110,7 @@ public class UserService {
     }
 
     private void sendEmail(String email, String verificationToken, String subject) {
-        String url = "http://localhost:9080/users/verify/" + verificationToken;
+        String url = "http://localhost:9080/api/user/verify/" + verificationToken;
         mailService.sendEmail(email, url, subject);
     }
 


### PR DESCRIPTION
## 연관 이슈
> #65 

## 작업 요약
- 파일 및 context 저장/조회 API 추가
- StoryService 저장/조회/삭제 로직 개선 및 S3 연동 강화

## 작업 상세 설명
- 엔티티 컬럼에 nullable = false 적용 및 썸네일 파일명 필드 추가
- Story 에러코드 추가 및 GlobalHandler 대응
- 스토리 저장 시 썸네일/페이지 이미지 UUID 기반 파일명으로 S3 업로드
- 스토리 조회 시 S3 Presigned URL 발급 방식으로 변경
- 스토리 삭제 시 S3 객체(썸네일 및 페이지 이미지)도 함께 삭제
- Controller → Service 레이어로 로직 이관, Controller 단 단순화
- 로그 이메일 포맷 및 주석 일부 정리

## 기타
- FastAPI ↔ BE 연동 시 전달되는 Story DTO 구조 확정 필요
- 추후 파일 삭제 시 예외처리/트랜잭션 롤백 정책 보완 필요
