### PR TITLE
#65 Refactor: Redis 설정을 프로퍼티 기반으로 수정 및 로컬-도커 환경 연동 확인

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/Controller/StoryController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/StoryController.java
@@ -59,7 +59,7 @@ public class StoryController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "스토리 목록 조회 성공")
     })
-    @GetMapping("/thumbnails")
+    @GetMapping("/stories/main")
     public ApiResponseDTO<List<StoryThumbnailResponseDTO>> getMainPageStories(
             @RequestHeader("Authorization") String accessToken,
             @RequestParam(defaultValue = "0") int page) {

--- a/src/main/java/com/gyeongditor/storyfield/config/RedisConfig.java
+++ b/src/main/java/com/gyeongditor/storyfield/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.gyeongditor.storyfield.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -12,10 +13,11 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories
 public class RedisConfig {
 
-    @Bean // Lettuce를 이용해 Redis 서버에 연결
-    public RedisConnectionFactory redisConnectionFactory() {
-        // 'redis'는 docker-compose 서비스 이름, 포트는 Redis 기본 6379
-        return new LettuceConnectionFactory("redis", 6379);
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(
+            @Value("${spring.data.redis.host}") String host,
+            @Value("${spring.data.redis.port}") int port) {
+        return new LettuceConnectionFactory(host, port);
     }
 
     @Bean // Redis 작업을 수행하기 위한 RedisTemplate 빈을 정의

--- a/src/main/java/com/gyeongditor/storyfield/response/SuccessCode.java
+++ b/src/main/java/com/gyeongditor/storyfield/response/SuccessCode.java
@@ -4,48 +4,48 @@ import org.springframework.http.HttpStatus;
 
 public enum SuccessCode {
 
-    // ===================== 1. 공통 성공 코드 =====================
+    // 1. 공통 성공 코드
     SUCCESS_200_001(HttpStatus.OK, "SUCCESS_200_001", "요청이 성공적으로 처리되었습니다."),
     SUCCESS_201_001(HttpStatus.CREATED, "SUCCESS_201_001", "리소스가 성공적으로 생성되었습니다."),
     SUCCESS_204_001(HttpStatus.NO_CONTENT, "SUCCESS_204_001", "요청이 성공적으로 처리되었으며 반환할 콘텐츠가 없습니다."),
 
-    // ===================== 2. 사용자 관련 =====================
+    // 2. 사용자 관련
     USER_201_001(HttpStatus.CREATED, "USER_201_001", "회원가입이 완료되었습니다."),
     USER_200_001(HttpStatus.OK, "USER_200_001", "회원 정보 조회가 성공적으로 완료되었습니다."),
     USER_200_002(HttpStatus.OK, "USER_200_002", "회원 정보가 성공적으로 수정되었습니다."),
     USER_200_003(HttpStatus.OK, "USER_200_003", "이메일 인증이 완료되었습니다."),
     USER_204_001(HttpStatus.NO_CONTENT, "USER_204_001", "회원이 성공적으로 삭제되었습니다."),
 
-    // ===================== 3. 인증/Auth =====================
+    // 3. 인증/Auth
     AUTH_200_001(HttpStatus.OK, "AUTH_200_001", "로그인이 성공적으로 완료되었습니다."),
     AUTH_200_002(HttpStatus.OK, "AUTH_200_002", "로그아웃이 성공적으로 완료되었습니다."),
     AUTH_200_007(HttpStatus.OK, "AUTH_200_003", "RT값으로 새로운 AT생성에 성공했습니다."),
 
-    // ===================== 4. 메일 =====================
+    // 4. 메일
     MAIL_200_001(HttpStatus.OK, "MAIL_200_001", "인증 메일이 성공적으로 전송되었습니다."),
     MAIL_200_002(HttpStatus.OK, "MAIL_200_002", "이메일 인증이 완료되었습니다."),
 
-    // ===================== 5. 스토리 관련 =====================
+    // 5. 스토리 관련
     STORY_201_001(HttpStatus.CREATED, "STORY_201_001", "스토리가 성공적으로 생성되었습니다."),
     STORY_200_001(HttpStatus.OK, "STORY_200_001", "스토리 페이지가 성공적으로 조회되었습니다."),
     STORY_200_002(HttpStatus.OK, "STORY_200_002", "메인 페이지 스토리 목록이 성공적으로 조회되었습니다."),
     STORY_204_001(HttpStatus.NO_CONTENT, "STORY_204_001", "스토리가 성공적으로 삭제되었습니다."),
-    // ===================== 6. OAuth2 인증 =====================
+    // 6. OAuth2 인증
     OAUTH2_200_001(HttpStatus.OK, "OAUTH2_200_001", "OAuth2 로그인 인증이 성공적으로 완료되었습니다."),
     OAUTH2_201_001(HttpStatus.CREATED, "OAUTH2_201_001", "신규 OAuth2 사용자가 성공적으로 생성되었습니다."),
-    // ===================== 7. 사용자 인증 =====================
+    // 7. 사용자 인증
     AUTH_200_003(HttpStatus.OK, "AUTH_200_003", "사용자 정보 로드가 성공적으로 완료되었습니다."),
     AUTH_200_004(HttpStatus.OK, "AUTH_200_004", "계정 상태가 정상입니다."),
     AUTH_200_005(HttpStatus.OK, "AUTH_200_005", "로그인 실패 횟수가 초기화되었습니다."),
     AUTH_200_006(HttpStatus.OK, "AUTH_200_006", "로그인 실패 횟수가 업데이트되었습니다."),
 
-    // ===================== 8. 파일 성공 =====================
+    // 8. 파일 성공
     FILE_200_001(HttpStatus.OK, "FILE_200_001", "파일 업로드 성공"),
     FILE_200_002(HttpStatus.OK, "FILE_200_002", "Presigned URL 생성 성공"),
     FILE_200_003(HttpStatus.OK, "FILE_200_003", "파일 URL 조회 성공"),
     FILE_204_001(HttpStatus.NO_CONTENT, "FILE_204_001", "파일 삭제 성공");
 
-    // ===================== 필드 =====================
+    // 필드
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/gyeongditor/storyfield/response/SuccessCode.java
+++ b/src/main/java/com/gyeongditor/storyfield/response/SuccessCode.java
@@ -29,6 +29,7 @@ public enum SuccessCode {
     STORY_201_001(HttpStatus.CREATED, "STORY_201_001", "스토리가 성공적으로 생성되었습니다."),
     STORY_200_001(HttpStatus.OK, "STORY_200_001", "스토리 페이지가 성공적으로 조회되었습니다."),
     STORY_200_002(HttpStatus.OK, "STORY_200_002", "메인 페이지 스토리 목록이 성공적으로 조회되었습니다."),
+    STORY_200_003(HttpStatus.OK, "STORY_200_003", "스토리 생성 요청 완료"),
     STORY_204_001(HttpStatus.NO_CONTENT, "STORY_204_001", "스토리가 성공적으로 삭제되었습니다."),
     // 6. OAuth2 인증
     OAUTH2_200_001(HttpStatus.OK, "OAUTH2_200_001", "OAuth2 로그인 인증이 성공적으로 완료되었습니다."),

--- a/src/main/java/com/gyeongditor/storyfield/service/StoryService.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/StoryService.java
@@ -114,9 +114,6 @@ public class StoryService {
     /**
      * 메인 페이지 스토리 목록 조회
      */
-    /**
-     * 메인 페이지 스토리 목록 조회
-     */
     public ApiResponseDTO<List<StoryThumbnailResponseDTO>> getMainPageStories(int page, String accessToken) {
         Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Story> storyPage = storyRepository.findAll(pageable);


### PR DESCRIPTION
## 연관 이슈
- #65

## 작업 요약
Redis 설정을 프로퍼티 기반으로 리팩터링하고, 로컬 IDE ↔ Docker(MySQL, Redis) 환경 간 연동을 검증했습니다.  
추가로 주석 및 URL 정리, 성공 코드 추가 작업을 반영했습니다.  

## 작업 상세 설명
- RedisConfig를 `@Value` 기반으로 수정하여 `application.properties`의 host/port 설정을 그대로 반영하도록 개선
- 로컬 IDE에서 실행 시 Docker의 MySQL(4307), Redis(8379) 컨테이너와 정상적으로 연결 가능 확인
- 불필요하거나 중복된 주석 삭제 및 일부 주석 문구 수정
- API URL 일부 변경 (가독성/일관성 개선)
- 이야기 생성 요청 성공 코드(`STORY_201_001`) 추가

## 기타
- Postman을 통한 multipart/form-data 요청 시 Authorization 헤더 처리 이슈가 있어 추후 SecurityContext 기반 인증으로 전환 고려가 필요합니다.