### PR TITLE
65 feature 파일 및 context 저장조회 api 추가

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
@@ -165,23 +165,23 @@ public class ImageController {
 //                    )
 //            )
 //    })
-////    @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-////    public ApiResponseDTO<List<String>> uploadImage(
-////            @Parameter(
-////                    description = "업로드할 이미지 파일들",
-////                    required = true,
-////                    content = @Content(
-////                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-////                            schema = @Schema(type = "string", format = "binary")
-////                    )
-////            )
-////            @RequestParam("files") List<MultipartFile> files,
-////            @Parameter(description = "Bearer AccessToken", required = true)
-////            @RequestHeader("Authorization") String authorizationHeader
-////    ) throws IOException {
-////        String accessToken = authorizationHeader.replace("Bearer ", "");
-////        return s3Service.uploadFiles(files, accessToken);
-////    }
+//    @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+//    public ApiResponseDTO<List<String>> uploadImage(
+//            @Parameter(
+//                    description = "업로드할 이미지 파일들",
+//                    required = true,
+//                    content = @Content(
+//                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+//                            schema = @Schema(type = "string", format = "binary")
+//                    )
+//            )
+//            @RequestParam("files") List<MultipartFile> files,
+//            @Parameter(description = "Bearer AccessToken", required = true)
+//            @RequestHeader("Authorization") String authorizationHeader
+//    ) throws IOException {
+//        String accessToken = authorizationHeader.replace("Bearer ", "");
+//        return s3Service.uploadFiles(files, accessToken);
+//   }
 //    @SneakyThrows
 //    @Operation(
 //            summary = "이미지 업로드",

--- a/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
@@ -98,172 +98,172 @@ public class ImageController {
         return s3Service.generatePresignedUrl(fileName, accessToken);
     }
 
-    @SneakyThrows
-    @Operation(
-            summary = "이미지 업로드",
-            description = "Multipart 형식으로 이미지를 업로드하고, 업로드된 이미지의 S3 URL을 반환합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "업로드 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-            {
-              "status": 200,
-              "code": "FILE_200_001",
-              "message": "파일 업로드 성공",
-              "data": "https://s3-....amazonaws.com/bucket/abc.png"
-            }
-            """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "AccessToken 누락 또는 유효하지 않음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-            {
-              "status": 401,
-              "code": "AUTH_401_012",
-              "message": "유효하지 않은 인증 토큰입니다.",
-              "data": null
-            }
-            """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "413",
-                    description = "허용된 요청 크기 초과",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-            {
-              "status": 413,
-              "code": "REQ_413_001",
-              "message": "허용된 요청 크기 초과",
-              "data": null
-            }
-            """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "업로드 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-            {
-              "status": 500,
-              "code": "FILE_500_001",
-              "message": "파일 업로드 중 오류 발생",
-              "data": null
-            }
-            """)
-                    )
-            )
-    })
-    @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponseDTO<List<String>> uploadImage(
-            @Parameter(
-                    description = "업로드할 이미지 파일들",
-                    required = true,
-                    content = @Content(
-                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                            schema = @Schema(type = "string", format = "binary")
-                    )
-            )
-            @RequestParam("files") List<MultipartFile> files,
-            @Parameter(description = "Bearer AccessToken", required = true)
-            @RequestHeader("Authorization") String authorizationHeader
-    ) throws IOException {
-        String accessToken = authorizationHeader.replace("Bearer ", "");
-        return s3Service.uploadFiles(files, accessToken);
-    }
-    @SneakyThrows
-    @Operation(
-            summary = "이미지 업로드",
-            description = "Multipart 형식으로 이미지를 업로드하고, 업로드된 이미지의 S3 URL을 반환합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "업로드 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-            {
-              "status": 200,
-              "code": "FILE_200_001",
-              "message": "파일 업로드 성공",
-              "data": "https://s3-....amazonaws.com/bucket/abc.png"
-            }
-            """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "AccessToken 누락 또는 유효하지 않음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-            {
-              "status": 401,
-              "code": "AUTH_401_012",
-              "message": "유효하지 않은 인증 토큰입니다.",
-              "data": null
-            }
-            """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "413",
-                    description = "허용된 요청 크기 초과",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-            {
-              "status": 413,
-              "code": "REQ_413_001",
-              "message": "허용된 요청 크기 초과",
-              "data": null
-            }
-            """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "업로드 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-            {
-              "status": 500,
-              "code": "FILE_500_001",
-              "message": "파일 업로드 중 오류 발생",
-              "data": null
-            }
-            """)
-                    )
-            )
-    })
-    @PostMapping(path = "/thumbnail/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponseDTO<String> uploadThumbnailFile(
-            @Parameter(description = "업로드할 썸네일 파일", required = true)
-            @RequestParam("file") MultipartFile file,
-
-            @Parameter(description = "JWT 액세스 토큰", required = true, example = "Bearer eyJhbGciOiJIUzI1NiJ9...")
-            @RequestHeader("Authorization") String authorizationHeader
-    ) throws IOException {
-
-        // Authorization 헤더에서 토큰 추출 (Bearer 접두사 제거)
-        String accessToken = authorizationHeader.replace("Bearer ", "");
-
-        // 서비스 호출
-        return  s3Service.uploadThumbnailFile(file, accessToken);
-    }
+//    @SneakyThrows
+//    @Operation(
+//            summary = "이미지 업로드",
+//            description = "Multipart 형식으로 이미지를 업로드하고, 업로드된 이미지의 S3 URL을 반환합니다."
+//    )
+//    @ApiResponses({
+//            @ApiResponse(
+//                    responseCode = "200",
+//                    description = "업로드 성공",
+//                    content = @Content(
+//                            mediaType = "application/json",
+//                            examples = @ExampleObject(value = """
+//            {
+//              "status": 200,
+//              "code": "FILE_200_001",
+//              "message": "파일 업로드 성공",
+//              "data": "https://s3-....amazonaws.com/bucket/abc.png"
+//            }
+//            """)
+//                    )
+//            ),
+//            @ApiResponse(
+//                    responseCode = "401",
+//                    description = "AccessToken 누락 또는 유효하지 않음",
+//                    content = @Content(
+//                            mediaType = "application/json",
+//                            examples = @ExampleObject(value = """
+//            {
+//              "status": 401,
+//              "code": "AUTH_401_012",
+//              "message": "유효하지 않은 인증 토큰입니다.",
+//              "data": null
+//            }
+//            """)
+//                    )
+//            ),
+//            @ApiResponse(
+//                    responseCode = "413",
+//                    description = "허용된 요청 크기 초과",
+//                    content = @Content(
+//                            mediaType = "application/json",
+//                            examples = @ExampleObject(value = """
+//            {
+//              "status": 413,
+//              "code": "REQ_413_001",
+//              "message": "허용된 요청 크기 초과",
+//              "data": null
+//            }
+//            """)
+//                    )
+//            ),
+//            @ApiResponse(
+//                    responseCode = "500",
+//                    description = "업로드 실패",
+//                    content = @Content(
+//                            mediaType = "application/json",
+//                            examples = @ExampleObject(value = """
+//            {
+//              "status": 500,
+//              "code": "FILE_500_001",
+//              "message": "파일 업로드 중 오류 발생",
+//              "data": null
+//            }
+//            """)
+//                    )
+//            )
+//    })
+////    @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+////    public ApiResponseDTO<List<String>> uploadImage(
+////            @Parameter(
+////                    description = "업로드할 이미지 파일들",
+////                    required = true,
+////                    content = @Content(
+////                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+////                            schema = @Schema(type = "string", format = "binary")
+////                    )
+////            )
+////            @RequestParam("files") List<MultipartFile> files,
+////            @Parameter(description = "Bearer AccessToken", required = true)
+////            @RequestHeader("Authorization") String authorizationHeader
+////    ) throws IOException {
+////        String accessToken = authorizationHeader.replace("Bearer ", "");
+////        return s3Service.uploadFiles(files, accessToken);
+////    }
+//    @SneakyThrows
+//    @Operation(
+//            summary = "이미지 업로드",
+//            description = "Multipart 형식으로 이미지를 업로드하고, 업로드된 이미지의 S3 URL을 반환합니다."
+//    )
+//    @ApiResponses({
+//            @ApiResponse(
+//                    responseCode = "200",
+//                    description = "업로드 성공",
+//                    content = @Content(
+//                            mediaType = "application/json",
+//                            examples = @ExampleObject(value = """
+//            {
+//              "status": 200,
+//              "code": "FILE_200_001",
+//              "message": "파일 업로드 성공",
+//              "data": "https://s3-....amazonaws.com/bucket/abc.png"
+//            }
+//            """)
+//                    )
+//            ),
+//            @ApiResponse(
+//                    responseCode = "401",
+//                    description = "AccessToken 누락 또는 유효하지 않음",
+//                    content = @Content(
+//                            mediaType = "application/json",
+//                            examples = @ExampleObject(value = """
+//            {
+//              "status": 401,
+//              "code": "AUTH_401_012",
+//              "message": "유효하지 않은 인증 토큰입니다.",
+//              "data": null
+//            }
+//            """)
+//                    )
+//            ),
+//            @ApiResponse(
+//                    responseCode = "413",
+//                    description = "허용된 요청 크기 초과",
+//                    content = @Content(
+//                            mediaType = "application/json",
+//                            examples = @ExampleObject(value = """
+//            {
+//              "status": 413,
+//              "code": "REQ_413_001",
+//              "message": "허용된 요청 크기 초과",
+//              "data": null
+//            }
+//            """)
+//                    )
+//            ),
+//            @ApiResponse(
+//                    responseCode = "500",
+//                    description = "업로드 실패",
+//                    content = @Content(
+//                            mediaType = "application/json",
+//                            examples = @ExampleObject(value = """
+//            {
+//              "status": 500,
+//              "code": "FILE_500_001",
+//              "message": "파일 업로드 중 오류 발생",
+//              "data": null
+//            }
+//            """)
+//                    )
+//            )
+//    })
+//    @PostMapping(path = "/thumbnail/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+//    public ApiResponseDTO<String> uploadThumbnailFile(
+//            @Parameter(description = "업로드할 썸네일 파일", required = true)
+//            @RequestParam("file") MultipartFile file,
+//
+//            @Parameter(description = "JWT 액세스 토큰", required = true, example = "Bearer eyJhbGciOiJIUzI1NiJ9...")
+//            @RequestHeader("Authorization") String authorizationHeader
+//    ) throws IOException {
+//
+//        // Authorization 헤더에서 토큰 추출 (Bearer 접두사 제거)
+//        String accessToken = authorizationHeader.replace("Bearer ", "");
+//
+//        // 서비스 호출
+//        return  s3Service.uploadThumbnailFile(file, accessToken);
+//    }
 
     @Operation(
             summary = "이미지 URL 조회",

--- a/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
@@ -258,9 +258,6 @@ public class ImageController {
             @RequestHeader("Authorization") String authorizationHeader
     ) throws IOException {
 
-        log.info("썸네일 파일 업로드 요청 - 파일명: {}, 크기: {} bytes",
-                file.getOriginalFilename(), file.getSize());
-
         // Authorization 헤더에서 토큰 추출 (Bearer 접두사 제거)
         String accessToken = authorizationHeader.replace("Bearer ", "");
 

--- a/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
@@ -2,6 +2,7 @@ package com.gyeongditor.storyfield.Controller;
 
 import com.gyeongditor.storyfield.dto.ApiResponseDTO;
 import com.gyeongditor.storyfield.service.S3Service;
+import io.jsonwebtoken.io.IOException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,14 +13,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestPart;
 
+import java.util.List;
+
 @Tag(name = "Image", description = "이미지")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/images")
 public class ImageController {
 
@@ -160,22 +165,107 @@ public class ImageController {
                     )
             )
     })
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponseDTO<String> uploadImage(
+    @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponseDTO<List<String>> uploadImage(
             @Parameter(
-                    description = "업로드할 이미지 파일",
+                    description = "업로드할 이미지 파일들",
                     required = true,
                     content = @Content(
                             mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
                             schema = @Schema(type = "string", format = "binary")
                     )
             )
-            @RequestParam("file") MultipartFile file,
+            @RequestParam("files") List<MultipartFile> files,
             @Parameter(description = "Bearer AccessToken", required = true)
             @RequestHeader("Authorization") String authorizationHeader
-    ) {
+    ) throws IOException {
         String accessToken = authorizationHeader.replace("Bearer ", "");
-        return s3Service.uploadFile(file, accessToken);
+        return s3Service.uploadFiles(files, accessToken);
+    }
+    @SneakyThrows
+    @Operation(
+            summary = "이미지 업로드",
+            description = "Multipart 형식으로 이미지를 업로드하고, 업로드된 이미지의 S3 URL을 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "업로드 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            {
+              "status": 200,
+              "code": "FILE_200_001",
+              "message": "파일 업로드 성공",
+              "data": "https://s3-....amazonaws.com/bucket/abc.png"
+            }
+            """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "AccessToken 누락 또는 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            {
+              "status": 401,
+              "code": "AUTH_401_012",
+              "message": "유효하지 않은 인증 토큰입니다.",
+              "data": null
+            }
+            """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "413",
+                    description = "허용된 요청 크기 초과",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            {
+              "status": 413,
+              "code": "REQ_413_001",
+              "message": "허용된 요청 크기 초과",
+              "data": null
+            }
+            """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "업로드 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            {
+              "status": 500,
+              "code": "FILE_500_001",
+              "message": "파일 업로드 중 오류 발생",
+              "data": null
+            }
+            """)
+                    )
+            )
+    })
+    @PostMapping(path = "/thumbnail/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponseDTO<String> uploadThumbnailFile(
+            @Parameter(description = "업로드할 썸네일 파일", required = true)
+            @RequestParam("file") MultipartFile file,
+
+            @Parameter(description = "JWT 액세스 토큰", required = true, example = "Bearer eyJhbGciOiJIUzI1NiJ9...")
+            @RequestHeader("Authorization") String authorizationHeader
+    ) throws IOException {
+
+        log.info("썸네일 파일 업로드 요청 - 파일명: {}, 크기: {} bytes",
+                file.getOriginalFilename(), file.getSize());
+
+        // Authorization 헤더에서 토큰 추출 (Bearer 접두사 제거)
+        String accessToken = authorizationHeader.replace("Bearer ", "");
+
+        // 서비스 호출
+        return  s3Service.uploadThumbnailFile(file, accessToken);
     }
 
     @Operation(

--- a/src/main/java/com/gyeongditor/storyfield/service/S3Service.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/S3Service.java
@@ -46,7 +46,7 @@ public class S3Service {
     }
 
     // 단순 파일 업로드 (ApiResponse 반환)
-    public ApiResponseDTO<List<String>> uploadFiles(List<MultipartFile> files, String accessToken) throws IOException {
+    public List<String> uploadFiles(List<MultipartFile> files, String accessToken) throws IOException {
         jwtTokenProvider.validateOrThrow(accessToken);
 
         List<String> uploadedFileNames = new ArrayList<>();
@@ -58,10 +58,10 @@ public class S3Service {
             }
         }
 
-        return ApiResponseDTO.success(SuccessCode.FILE_200_001, uploadedFileNames);
+        return uploadedFileNames;
     }
 
-    public ApiResponseDTO<String> uploadThumbnailFile(MultipartFile file, String accessToken) throws IOException {
+    public String uploadThumbnailFile(MultipartFile file, String accessToken) throws IOException {
         // 1. 토큰 검증
         jwtTokenProvider.validateOrThrow(accessToken);
 
@@ -73,7 +73,7 @@ public class S3Service {
 
         // 4. 업로드된 파일 URL 반환
 
-        return ApiResponseDTO.success(SuccessCode.FILE_200_001, fileName);
+        return fileName;
     }
 
 

--- a/src/main/java/com/gyeongditor/storyfield/service/S3Service.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/S3Service.java
@@ -14,7 +14,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -25,6 +27,7 @@ public class S3Service {
     private final AwsProperties awsProperties;
     private final JwtTokenProvider jwtTokenProvider;
 
+    // Presigned URL 발급
     public ApiResponseDTO<String> generatePresignedUrl(String fileName, String accessToken) {
         jwtTokenProvider.validateOrThrow(accessToken);
 
@@ -42,20 +45,52 @@ public class S3Service {
         return ApiResponseDTO.success(SuccessCode.FILE_200_002, presignedUrl);
     }
 
-    public ApiResponseDTO<String> uploadFile(MultipartFile file, String accessToken) throws IOException {
+    // 단순 파일 업로드 (ApiResponse 반환)
+    public ApiResponseDTO<List<String>> uploadFiles(List<MultipartFile> files, String accessToken) throws IOException {
         jwtTokenProvider.validateOrThrow(accessToken);
 
+        List<String> uploadedFileNames = new ArrayList<>();
+        for (MultipartFile file : files) {
+            if (file != null && !file.isEmpty()) {
+                String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+                upload(file, fileName); // 내부 private upload 호출
+                uploadedFileNames.add(fileName);
+            }
+        }
+
+        return ApiResponseDTO.success(SuccessCode.FILE_200_001, uploadedFileNames);
+    }
+
+    public ApiResponseDTO<String> uploadThumbnailFile(MultipartFile file, String accessToken) throws IOException {
+        // 1. 토큰 검증
+        jwtTokenProvider.validateOrThrow(accessToken);
+
+        // 2. 파일명 생성 (UUID 붙이기)
         String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
 
+        // 3. 업로드
+        upload(file, fileName); // 내부 private upload 호출
+
+        // 4. 업로드된 파일 URL 반환
+
+        return ApiResponseDTO.success(SuccessCode.FILE_200_001, fileName);
+    }
+
+
+    // 내부 공통 업로드 로직
+    private void upload(MultipartFile file, String fileName) throws IOException {
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(file.getSize());
         metadata.setContentType(file.getContentType());
 
-        amazonS3.putObject(awsProperties.getBucket(), fileName, file.getInputStream(), metadata);
-
-        return ApiResponseDTO.success(SuccessCode.FILE_200_001, getFileUrl(fileName));
+        amazonS3.putObject(
+                awsProperties.getBucket(),
+                fileName,
+                file.getInputStream(), // IOException 발생 가능
+                metadata
+        );
     }
-
+    // 단순 URL 조회
     public ApiResponseDTO<String> getFileUrlResponse(String fileName, String accessToken) {
         jwtTokenProvider.validateOrThrow(accessToken);
         return ApiResponseDTO.success(SuccessCode.FILE_200_003, getFileUrl(fileName));


### PR DESCRIPTION
## 연관 이슈
> #65 
## 작업 요약
FastAPI 서버로부터 스토리 데이터(JSON)와 이미지 파일들을 `multipart/form-data` 형식으로 받아 저장하는 API 엔드포인트를 구현하고, 관련 비즈니스 로직을 수정합니다.

## 작업 상세 설명
###  `StoryController` 수정: Multipart 요청 처리
- `POST /stories/save` 엔드포인트의 `Content-Type`을 `application/json`에서 `multipart/form-data`로 변경했습니다.
- `@RequestBody` 대신 `@RequestPart` 어노테이션을 사용하여 요청을 세 부분으로 나누어 받도록 수정했습니다.
  - `saveStoryDTO` (JSON String): 스토리의 메타데이터
  - `thumbnail` (MultipartFile): 대표 썸네일 이미지 파일
  - `pageImages` (List<MultipartFile>): 각 페이지에 해당하는 이미지 파일 목록
- 전달받은 JSON 문자열(`saveStoryDtoString`)을 `ObjectMapper`를 통해 `SaveStoryDTO` 객체로 변환하는 로직을 추가했습니다.
- `HttpServletRequest`에서 직접 헤더를 추출하는 대신 `@RequestHeader`를 사용하여 인증 토큰을 더 명시적으로 받도록 개선했습니다.

## 기타
- 본 API는 사용자 클라이언트가 아닌 **FastAPI 서버로부터 호출되는 것을 전제로 구현**되었습니다.