### PR TITLE
Hotfix: FastAPI 통신 로직을 Controller에서 분리하여 전용 Client 클래스 도입

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/Controller/HealthController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/HealthController.java
@@ -1,15 +1,22 @@
 package com.gyeongditor.storyfield.Controller;
 
+import com.gyeongditor.storyfield.config.FastApiClient;
 import com.gyeongditor.storyfield.dto.ApiResponseDTO;
 import com.gyeongditor.storyfield.response.SuccessCode;
 import com.gyeongditor.storyfield.swagger.api.HealthApi;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @RestController
+@RequiredArgsConstructor
 public class HealthController implements HealthApi {
+
+    private final FastApiClient fastApiClient;
 
     @Override
     public ApiResponseDTO<String> ping() {
-        return ApiResponseDTO.success(SuccessCode.SUCCESS_200_001, "OK");
+        String fastApiResponse = fastApiClient.ping();
+        return ApiResponseDTO.success(SuccessCode.SUCCESS_200_001, fastApiResponse);
     }
 }

--- a/src/main/java/com/gyeongditor/storyfield/Controller/StoryController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/StoryController.java
@@ -1,8 +1,10 @@
 package com.gyeongditor.storyfield.Controller;
 
+import com.gyeongditor.storyfield.config.FastApiClient;
 import com.gyeongditor.storyfield.dto.ApiResponseDTO;
 import com.gyeongditor.storyfield.dto.Story.StoryPageResponseDTO;
 import com.gyeongditor.storyfield.dto.Story.StoryThumbnailResponseDTO;
+import com.gyeongditor.storyfield.response.SuccessCode;
 import com.gyeongditor.storyfield.service.StoryService;
 import com.gyeongditor.storyfield.swagger.api.StoryApi;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,14 +21,15 @@ import java.util.UUID;
 public class StoryController implements StoryApi {
 
     private final StoryService storyService;
+    private final FastApiClient fastApiClient;
 
     @Override
-    public ApiResponseDTO<String> saveStory(HttpServletRequest request, String saveStoryDtoString, MultipartFile thumbnail, List<MultipartFile> pageImages) {
-        try {
-            return storyService.saveStoryFromFastApi(request, saveStoryDtoString, thumbnail, pageImages);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    public ApiResponseDTO<String> saveStory(HttpServletRequest request,
+                                            String saveStoryDtoString,
+                                            MultipartFile thumbnail,
+                                            List<MultipartFile> pageImages) {
+        String response = fastApiClient.saveStory(saveStoryDtoString, thumbnail, pageImages);
+        return ApiResponseDTO.success(SuccessCode.SUCCESS_200_001, response);
     }
     @Override
     public ApiResponseDTO<List<StoryPageResponseDTO>> getStoryPages(HttpServletRequest request, UUID storyId) {

--- a/src/main/java/com/gyeongditor/storyfield/config/FastApiClient.java
+++ b/src/main/java/com/gyeongditor/storyfield/config/FastApiClient.java
@@ -1,0 +1,41 @@
+package com.gyeongditor.storyfield.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class FastApiClient {
+
+    private final WebClient fastApiWebClient;
+
+    public String ping() {
+        return fastApiWebClient.get()
+                .uri("/ping")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    public String saveStory(String saveStoryDtoString,
+                            MultipartFile thumbnail,
+                            List<MultipartFile> pageImages) {
+        return fastApiWebClient.post()
+                .uri("/stories/save")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData("saveStoryDTO", saveStoryDtoString)
+                        .with("thumbnail", thumbnail.getResource())
+                        .with("pageImages", pageImages.stream().map(MultipartFile::getResource).toList())
+                )
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -87,3 +87,12 @@ aws.s3.credentials.accessKey=${S3_ACCESSKEY}
 aws.s3.credentials.secretKey=${S3_SECRETKEY}
 aws.s3.region=ap-northeast-2
 aws.s3.bucket=storyfield-image--bucket
+
+# FastAPI
+fastapi.base-url=http://localhost:8000
+
+# ????(ms)
+fastapi.connect-timeout-ms=1000
+fastapi.read-timeout-ms=5000
+fastapi.write-timeout-ms=3000
+fastapi.request-timeout-ms=6000


### PR DESCRIPTION
## 작업 요약
> 기존 Controller 내부 로직을 직접 처리하지 않고, FastAPI와의 통신을 통해 동작하도록 수정

## 작업 상세 내용
- `FastApiClient` 클래스 추가: FastAPI 서버와의 HTTP 통신 전담
  - `/ping` API 호출
  - `/stories/save` API 호출
- `HealthController`, `StoryController` 가 `FastApiClient`를 사용하도록 변경
- Controller는 응답을 `ApiResponseDTO` 규격으로 래핑만 담당하도록 단순화

## 기타
> Controller는 API 스펙 및 응답 형식 유지, 외부 연산/저장은 FastAPI로 위임