### PR TITLE
UUID 컬럼 매핑 및 DB 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // DB
-    runtimeOnly 'com.mysql:mysql-connector-j'
+      runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
 
     // Docker Compose (개발용)
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,18 +1,22 @@
 version: "3.8"
 
 services:
-  mysql:
-    image: gyeongditor/mysql-custom:latest
-    container_name: storyfield-mysql
+  mariadb:
+    image: gyeongditor/mariadb:11.4
+    container_name: storyfield-mariadb
     restart: unless-stopped
     ports:
-      - "4307:3306"
+      - "4306:3306"
+    env_file:
+      - ./.env
+    volumes:
+      - mariadb_data:/var/lib/mysql
 
   redis:
     image: gyeongditor/storyfield-redis:latest
     container_name: storyfield-redis
     depends_on:
-      - mysql
+      - mariadb
     restart: unless-stopped
     ports:
       - "8379:6379"
@@ -30,30 +34,28 @@ services:
     image: gyeongditor/story-field-be:latest
     container_name: storyfield-app
     depends_on:
-      - mysql
+      - mariadb
       - redis
       - fastapi
     restart: unless-stopped
     ports:
       - "9080:8080"
-    # 여기서 .env를 컨테이너 환경으로 주입
     env_file:
       - ./.env
-    # DB/FastAPI 준비될 때까지 대기 후 실행 (wait-for-it.sh 불필요)
     environment:
-      DB_HOST: mysql
+      DB_HOST: mariadb
       DB_PORT: "3306"
     entrypoint:
       - sh
       - -c
       - |
         set -e
-        echo "🔎 checking MySQL at ${DB_HOST}:${DB_PORT}"
+        echo "🔎 checking MariaDB at ${DB_HOST}:${DB_PORT}"
         until nc -z "$$DB_HOST" "$$DB_PORT"; do
-          echo "⏳ waiting for MySQL..."
+          echo "⏳ waiting for MariaDB..."
           sleep 1
         done
-        echo "✅ MySQL OK"
+        echo "✅ MariaDB OK"
         echo "🔎 checking FastAPI at fastapi:8000"
         until nc -z fastapi 8000; do
           echo "⏳ waiting for FastAPI..."
@@ -61,3 +63,6 @@ services:
         done
         echo "✅ FastAPI OK"
         exec java -jar /app/app.jar
+
+volumes:
+  mariadb_data:

--- a/src/main/java/com/gyeongditor/storyfield/Entity/CustomUserDetails.java
+++ b/src/main/java/com/gyeongditor/storyfield/Entity/CustomUserDetails.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
-    private final UUID userId; // 여기에 UUID 추가
+    private final String userId; // 여기에 UUID 추가
     private final String email;
     private final String password;
     private final String username;

--- a/src/main/java/com/gyeongditor/storyfield/Entity/User.java
+++ b/src/main/java/com/gyeongditor/storyfield/Entity/User.java
@@ -22,8 +22,8 @@ public class User {
     @Id
     @GeneratedValue(generator = "UUID")
     @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
-    @Column(name = "user_id", columnDefinition = "BINARY(16)")
-    private UUID userId;
+    @Column(name = "user_id", length = 36, nullable = false, updatable = false)
+    private String userId;
 
     @Column(nullable = false)
     private String email;

--- a/src/main/java/com/gyeongditor/storyfield/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/UserServiceImpl.java
@@ -107,7 +107,7 @@ public class UserServiceImpl implements UserService {
     public ApiResponseDTO<Void> deleteUserByAccessToken(HttpServletRequest request) {
         String accessToken = jwtTokenProvider.resolveToken(request);
         User user = getUserFromToken(accessToken);
-        userRepository.deleteById(user.getUserId());
+        userRepository.deleteById(UUID.fromString(user.getUserId()));
         return ApiResponseDTO.success(SuccessCode.USER_204_001, null);
     }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,12 +1,13 @@
 spring.application.name=storyfield
 
-spring.datasource.url=${SPRING_DATASOURCE_URL}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER_CLASS_NAME}
 
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO}
+spring.jpa.show-sql=${SPRING_JPA_SHOW_SQL}
+spring.jpa.properties.hibernate.dialect=${SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT}
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.data.redis.host=redis


### PR DESCRIPTION
## 연관 이슈
#100 

## 작업 요약
> UUID 타입 컬럼을 `String` 기반 `VARCHAR(36)`으로 통일하고, MySQL → MariaDB 마이그레이션 과정에서 발생한 스키마 불일치를 해결

## 작업 상세 설명
- `User.user_id` 및 관련 엔티티의 PK/ FK를 `UUID → String(VARCHAR(36))` 으로 수정  
- MariaDB 환경에서 컬럼 길이 불일치(`Data too long for column`) 오류 해소  
- 외래키 제약(FK)와 DDL 업데이트 충돌 방지를 위해 DB 초기화 후 JPA DDL 생성 방식으로 마이그레이션 수행  
- `application.properties`와 `.env`를 MariaDB 기반으로 정리하여 통일된 환경변수 관리 구조 적용

## 기타
- 추후 운영 환경에서는 **데이터 보존 정책**에 맞춰 Flyway/Liquibase 기반 마이그레이션 도입 고려 필요  
- 로컬/도커 환경 모두 MariaDB 11.4 기준으로 테스트 완료  
