### PR TITLE
Refactor: uerId String 으로 변경

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/repository/UserRepository.java
+++ b/src/main/java/com/gyeongditor/storyfield/repository/UserRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, String> {
 
     Optional<User> findByEmail(String email);
 

--- a/src/main/java/com/gyeongditor/storyfield/service/impl/CustomUserDetailsServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/CustomUserDetailsServiceImpl.java
@@ -110,7 +110,7 @@ public class CustomUserDetailsServiceImpl implements CustomUserDetailsService {
 
     @Override
     public CustomUserDetails loadUserByUUID(String uuid) {
-        User user = userRepository.findById(UUID.fromString(uuid))
+        User user = userRepository.findById(uuid)
                 .orElseThrow(() -> new CustomException(
                         ErrorCode.USER_404_001,
                         "사용자를 찾을 수 없습니다."

--- a/src/main/java/com/gyeongditor/storyfield/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/UserServiceImpl.java
@@ -107,7 +107,7 @@ public class UserServiceImpl implements UserService {
     public ApiResponseDTO<Void> deleteUserByAccessToken(HttpServletRequest request) {
         String accessToken = jwtTokenProvider.resolveToken(request);
         User user = getUserFromToken(accessToken);
-        userRepository.deleteById(UUID.fromString(user.getUserId()));
+        userRepository.deleteById(user.getUserId());
         return ApiResponseDTO.success(SuccessCode.USER_204_001, null);
     }
 


### PR DESCRIPTION
## 연관 이슈
#100 

## 작업 요약
> `userId`가 `UUID` → `String`으로 변경됨에 따라 관련 서비스 로직 및 `UserRepository`를 수정

## 작업 상세 설명
- 엔티티 `User`의 PK 타입을 `String`으로 변경 (`VARCHAR(36)`)
- `UserRepository` 및 파생 메서드 시그니처(UUID → String) 변경
- 서비스 레이어에서 `UUID` 변환 로직 제거 및 String 기반 처리로 단순화
- 연관된 엔티티(`Story`, `Audio`, etc.)의 FK 타입도 동일하게 수정

## 기타
- DB 초기화 시 `user_id` 컬럼을 `VARCHAR(36)`으로 생성하여 MariaDB와의 불일치 문제 방지
- 추후 데이터 마이그레이션 자동화를 위해 Flyway/Liquibase 고려 필요