### PR TITLE
Feat: init.sql로 스키마 생성 및 사용자 권한 부여

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
       - ./.env
     volumes:
       - mariadb_data:/var/lib/mysql
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
 
   redis:
     image: gyeongditor/storyfield-redis:latest


### PR DESCRIPTION
## 연관 이슈
> #100 

## 작업 요약
Docker Compose 환경에서 MariaDB 초기 스키마 자동 생성 설정 추가

## 작업 상세 설명
- `init.sql`을 `docker-entrypoint-initdb.d/init.sql` 경로에 마운트하여 컨테이너 실행 시 자동으로 DB 초기화
- `mariadb_data` 볼륨을 `/var/lib/mysql`에 마운트하여 데이터 영속성 보장
- `.env` 파일 연동을 통해 환경 변수 기반 설정 유지

## 기타
- `init.sql` 수정 시 컨테이너 재생성해야 반영됨  
- 데이터베이스를 보존하려면 `mariadb_data` 볼륨 삭제 없이 컨테이너만 재시작할 것