### PR TITLE
Refactor: 메일센더에 발신자 추가

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/service/impl/MailServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/MailServiceImpl.java
@@ -5,6 +5,7 @@ import com.gyeongditor.storyfield.response.SuccessCode;
 import com.gyeongditor.storyfield.service.MailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -16,9 +17,13 @@ public class MailServiceImpl implements MailService {
 
     private final JavaMailSender javaMailSender;
 
+    @Value("${spring.mail.username}")
+    private String fromAddress;
+
     @Override
     public ApiResponseDTO<String> sendEmail(String to, String verificationUrl, String subject) {
         SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
         message.setTo(to);
         message.setSubject(subject);
         message.setText("이메일 인증을 완료하려면 아래 링크를 클릭하세요:\n\n" + verificationUrl);


### PR DESCRIPTION
## 연관 이슈
> #106 

## 작업 요약
> 메일 발송 시 발신자(`from`)가 누락되어 발생한 오류를 해결하기 위해 `MailServiceImpl`에 발신자 설정을 추가했습니다.

## 작업 상세 설명
> - `application.yml`의 `spring.mail.username` 값을 발신자로 사용하도록 `@Value` 주입  
> - `SimpleMailMessage.setFrom(fromAddress)` 호출 추가  
> - 메일 로그에 발신자 주소도 함께 출력되도록 개선  

## 기타
> 장기적으로는 Amazon SES 등 외부 메일 서비스 전환 고려 필요
