### PR TITLE
Refactor: 사용자 정보 수정 시 이메일 인증 로직 변경

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/Entity/User.java
+++ b/src/main/java/com/gyeongditor/storyfield/Entity/User.java
@@ -54,14 +54,18 @@ public class User {
     public void updateUser(UpdateUserDTO updateUserDTO, PasswordEncoder passwordEncoder, String mailVerificationToken) {
         this.username = updateUserDTO.getUsername();
         this.email = updateUserDTO.getEmail();
-        this.mailVerificationToken = mailVerificationToken;
-        this.enabled = false;
 
-        // 새로운 비밀번호가 null이 아니고, 기존 비밀번호와 다를 때만 인코딩하여 업데이트
+        // 이메일이 변경된 경우에만 인증 토큰과 enabled 상태 갱신
+        if (mailVerificationToken != null) {
+            this.mailVerificationToken = mailVerificationToken;
+            this.enabled = false;
+        }
+
         if (updateUserDTO.getPassword() != null && !updateUserDTO.getPassword().equals(this.password)) {
             this.password = passwordEncoder.encode(updateUserDTO.getPassword());
         }
     }
+    
 
     public void updateOAuthUser(String username, String email, String socialType, String socialId) {
         this.username = username;

--- a/src/main/java/com/gyeongditor/storyfield/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/UserServiceImpl.java
@@ -90,18 +90,20 @@ public class UserServiceImpl implements UserService {
         String accessToken = jwtTokenProvider.resolveToken(request);
         User user = getUserFromToken(accessToken);
 
+        // 이메일 변경 여부는 굳이 체크 안 하고, 토큰 발급 여부로만 분기
+        String verificationToken = null;
         if (!user.getEmail().equals(updateUserDTO.getEmail())) {
-            // 이메일 변경 시 인증 로직 추가 가능
+            verificationToken = UUID.randomUUID().toString();
+            sendEmail(updateUserDTO.getEmail(), verificationToken, "회원 정보 수정용 이메일 인증");
         }
 
-        String verificationToken = UUID.randomUUID().toString();
         user.updateUser(updateUserDTO, passwordEncoder, verificationToken);
-        sendEmail(user.getEmail(), verificationToken, "회원 정보 수정용 이메일 인증");
-
         userRepository.save(user);
+
         UserResponseDTO dto = new UserResponseDTO(user.getEmail(), user.getUsername());
         return ApiResponseDTO.success(SuccessCode.USER_200_002, dto);
     }
+
 
     @Override
     public ApiResponseDTO<Void> deleteUserByAccessToken(HttpServletRequest request) {


### PR DESCRIPTION
## 연관 이슈
> #107 

## 작업 요약
> 사용자 정보 수정 시 불필요한 인증 제거

## 작업 상세 설명
> 사용자 정보 수정 시 불필요한 인증 제거 및 이메일 변경 시만 이메일 재인증으로 수정
## 기타
> 추가적으로 알아야 할 사항 설명
