### PR TITLE
CD: 맥미니 셀프 호스티드 러너 CD 워크플로우 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,43 @@
+name: CD - Deploy on Macmini
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/story-field-be
+
+jobs:
+  build-and-deploy:
+    runs-on: [self-hosted, macOS]   # 또는 [self-hosted, macmini] (라벨에 맞춰 수정)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Build JAR (skip tests)
+        run: ./gradlew clean build -x test
+
+      - name: Docker login
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build & Push Docker Image (multi-arch)
+        run: |
+          docker buildx create --use --name sf_builder || docker buildx use sf_builder
+          docker run --privileged --rm tonistiigi/binfmt:latest --install all || true
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t $IMAGE_NAME:latest \
+            --push .
+
+      - name: Deploy with Docker Compose
+        run: |
+          cd /Users/gyeongditor/Documents
+          docker compose pull
+          docker compose up -d
+
+      - name: Check containers
+        run: docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"


### PR DESCRIPTION
## 연관 이슈
> #112 

## 작업 요약
맥미니 서버에 셀프 호스티드 러너 기반의 CD 워크플로우를 추가했습니다. main 브랜치 머지 시 자동으로 빌드 및 배포가 이루어지도록 설정했습니다.

## 작업 상세 설명
- .github/workflows/cd.yml 파일 추가
- main 브랜치에 push/merge될 경우만 워크플로우 실행
- Gradle 빌드 후 Docker 멀티 아키텍처 이미지 빌드 및 Docker Hub에 푸시
- 맥미니 러너에서 docker compose pull && docker compose up -d 실행하여 자동 배포

## 기타
- GitHub Secrets에 DOCKER_USERNAME, DOCKER_PASSWORD 등록 필요
- 러너 라벨(macmini) 변경 시 runs-on 값도 수정해야 함
- 현재는 latest 태그 기준으로 배포되므로 버전 태그 전략은 추후 협의 필요
