### PR TITLE
Fix: 불필요한 gradle build 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,43 @@
+name: CD - Deploy on Macmini
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/story-field-be
+
+jobs:
+  build-and-deploy:
+    runs-on: [self-hosted, macOS]   # 또는 [self-hosted, macmini] (라벨에 맞춰 수정)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Build JAR (skip tests)
+        run: ./gradlew clean build -x test
+
+      - name: Docker login
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build & Push Docker Image (multi-arch)
+        run: |
+          docker buildx create --use --name sf_builder || docker buildx use sf_builder
+          docker run --privileged --rm tonistiigi/binfmt:latest --install all || true
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t $IMAGE_NAME:latest \
+            --push .
+
+      - name: Deploy with Docker Compose
+        run: |
+          cd /Users/gyeongditor/Documents
+          docker compose pull
+          docker compose up -d
+
+      - name: Check containers
+        run: docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,53 +1,26 @@
-name: CI - Build and Push (no build-time secrets)
+name: CD - Deploy on Macmini
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main" ]
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/story-field-be
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  deploy:
+    runs-on: [self-hosted, macOS]   # runner 라벨 맞추기
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+      - name: Docker login
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Deploy with Docker Compose
+        run: |
+          cd /Users/gyeongditor/Documents
+          docker compose pull
+          docker compose up -d
 
-      - name: Build JAR (skip tests)
-        run: ./gradlew clean build -x test
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta (tags & labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=ref,event=branch
-            type=sha
-
-      - name: Build & Push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Check containers
+        run: docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"


### PR DESCRIPTION
## 연관 이슈
> #112 

## 작업 요약
> CI에서 이미 빌드 및 Docker 이미지 푸시를 수행하므로, CD 단계에서는 불필요한 Gradle 빌드를 제거하고 배포만 진행하도록 워크플로우를 단순화했습니다.

## 작업 상세 설명
- CD 워크플로우에서 ./gradlew clean build -x test 단계 제거
- Docker Hub 로그인 후 docker compose pull 및 docker compose up -d만 수행하도록 수정
- 배포 완료 후 컨테이너 상태 확인(docker ps) 로직 유지

## 기타
- CI/CD 역할 분리를 명확히 하여 빌드 중복을 방지하고 배포 속도 개선
- Runner 라벨(macOS, self-hosted) 확인 필요
