### PR TITLE
Refactor: macmini 경로 하드코딩 제거, Keychain 우회, compose 배포만 수행

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,43 +1,66 @@
+# .github/workflows/cd-macmini.yml
 name: CD - Deploy on Macmini
 
 on:
   push:
-    branches: [ "main" ]
-
-env:
-  IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/story-field-be
+    branches: ["main"]
 
 jobs:
-  build-and-deploy:
-    runs-on: [self-hosted, macOS]   # 또는 [self-hosted, macmini] (라벨에 맞춰 수정)
+  deploy:
+    runs-on: [self-hosted, macOS]  # 라벨에 맞춰 조정: [self-hosted], [self-hosted, macOS, ARM64] 등
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "temurin"
+      - name: Resolve dynamic paths (no hardcoding)
+        run: |
+          # DEPLOY_DIR: repo variable 있으면 사용, 없으면 $HOME/Documents
+          if [ -n "${{ vars.DEPLOY_DIR }}" ]; then
+            echo "DEPLOY_DIR=${{ vars.DEPLOY_DIR }}" >> "$GITHUB_ENV"
+          else
+            echo "DEPLOY_DIR=$HOME/Documents" >> "$GITHUB_ENV"
+          fi
 
-      - name: Build JAR (skip tests)
-        run: ./gradlew clean build -x test
+          # DOCKER_CONFIG: repo variable 있으면 사용, 없으면 $RUNNER_TEMP/.docker
+          if [ -n "${{ vars.DOCKER_CONFIG }}" ]; then
+            echo "DOCKER_CONFIG=${{ vars.DOCKER_CONFIG }}" >> "$GITHUB_ENV"
+          else
+            echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
+          fi
+
+          echo "Using DEPLOY_DIR=$DEPLOY_DIR"
+          echo "Using DOCKER_CONFIG=$DOCKER_CONFIG"
+
+      - name: Quick daemon check
+        run: |
+          set -e
+          docker version
+          docker info
+
+      - name: Disable macOS Keychain credsStore (per-job)
+        run: |
+          mkdir -p "$DOCKER_CONFIG"
+          echo '{"auths": {}, "credsStore": ""}' > "$DOCKER_CONFIG/config.json"
+
+      - name: Registry reachability sanity check
+        run: curl -sS https://registry-1.docker.io/v2/ || true
 
       - name: Docker login
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        uses: docker/login-action@v3
+        timeout-minutes: 3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build & Push Docker Image (multi-arch)
-        run: |
-          docker buildx create --use --name sf_builder || docker buildx use sf_builder
-          docker run --privileged --rm tonistiigi/binfmt:latest --install all || true
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            -t $IMAGE_NAME:latest \
-            --push .
+      - name: Pull images with compose
+        working-directory: ${{ env.DEPLOY_DIR }}
+        run: docker compose pull
+        timeout-minutes: 10
 
-      - name: Deploy with Docker Compose
-        run: |
-          cd /Users/gyeongditor/Documents
-          docker compose pull
-          docker compose up -d
+      - name: Deploy with compose
+        working-directory: ${{ env.DEPLOY_DIR }}
+        run: docker compose up -d
 
       - name: Check containers
         run: docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"


### PR DESCRIPTION
## 연관 이슈
#112 

## 작업 요약
CD 워크플로우를 배포 전용으로 단순화하고, macOS Keychain 이슈를 우회하며, 배포 경로 하드코딩을 제거했습니다. compose 기반으로 최신 이미지를 pull 후 up -d만 수행합니다.

## 작업 상세 설명
- Keychain 우회
  - DOCKER_CONFIG를 잡 범위로 /tmp 혹은 RUNNER_TEMP 하위에 생성
  - credsStore를 빈 문자열로 설정해 비-인터랙티브 로그인 무한대기 차단
- 경로 하드코딩 제거
  - DEPLOY_DIR, DOCKER_CONFIG를 Repository Variables로 주입 가능
  - 미설정 시 HOME/Documents, RUNNER_TEMP/.docker로 자동 해석
- 배포 전용 단순화
  - CI에서 이미지 빌드·푸시 완료 전제
  - CD는 docker compose pull → docker compose up -d만 수행
- 안정성 보강
  - docker version, docker info로 데몬 사전 점검
  - registry reachability 체크 추가
  - docker/login-action에 timeout 적용으로 장기 대기 방지

## 기타
- 필수 시크릿: DOCKER_USERNAME, DOCKER_PASSWORD
- 선택 변수: DEPLOY_DIR, DOCKER_CONFIG(Repository Variables). 없으면 기본값으로 동작
- 러너 라벨: self-hosted, macOS, ARM64 등 러너 화면과 일치하도록 runs-on 설정 필요