### PR TITLE
Refactor: Keychain 우회, 경로 변수화, compose 배포 일원화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, macOS]  # 라벨에 맞춰 조정: [self-hosted], [self-hosted, macOS, ARM64] 등
+    runs-on: [self-hosted, macmini]
 
     steps:
       - name: Checkout
@@ -15,52 +15,71 @@ jobs:
 
       - name: Resolve dynamic paths (no hardcoding)
         run: |
-          # DEPLOY_DIR: repo variable 있으면 사용, 없으면 $HOME/Documents
           if [ -n "${{ vars.DEPLOY_DIR }}" ]; then
             echo "DEPLOY_DIR=${{ vars.DEPLOY_DIR }}" >> "$GITHUB_ENV"
           else
             echo "DEPLOY_DIR=$HOME/Documents" >> "$GITHUB_ENV"
           fi
-
-          # DOCKER_CONFIG: repo variable 있으면 사용, 없으면 $RUNNER_TEMP/.docker
           if [ -n "${{ vars.DOCKER_CONFIG }}" ]; then
             echo "DOCKER_CONFIG=${{ vars.DOCKER_CONFIG }}" >> "$GITHUB_ENV"
           else
             echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
           fi
 
-          echo "Using DEPLOY_DIR=$DEPLOY_DIR"
-          echo "Using DOCKER_CONFIG=$DOCKER_CONFIG"
-
-      - name: Quick daemon check
+      - name: Show resolved paths
         run: |
-          set -e
+          echo "DEPLOY_DIR=$DEPLOY_DIR"
+          echo "DOCKER_CONFIG=$DOCKER_CONFIG"
+
+      - name: Quick daemon & context check
+        run: |
+          set -euxo pipefail
           docker version
           docker info
+          docker context ls
 
-      - name: Disable macOS Keychain credsStore (per-job)
+      # Keychain 우회: 잡 전용 docker config 생성 + credsStore 비활성화
+      - name: Prepare per-job Docker config (bypass Keychain)
         run: |
+          set -euxo pipefail
           mkdir -p "$DOCKER_CONFIG"
-          echo '{"auths": {}, "credsStore": ""}' > "$DOCKER_CONFIG/config.json"
+          printf '%s\n' '{"auths": {}, "credsStore": ""}' > "$DOCKER_CONFIG/config.json"
+          cat "$DOCKER_CONFIG/config.json"
 
-      - name: Registry reachability sanity check
-        run: curl -sS https://registry-1.docker.io/v2/ || true
+      # 네트워크 확인(느리면 여기서 보임)
+      - name: Network sanity check to Docker Hub
+        run: |
+          set -euxo pipefail
+          curl -I --max-time 10 https://registry-1.docker.io/v2/ || true
 
-      - name: Docker login
-        uses: docker/login-action@v3
-        timeout-minutes: 3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # 기존의 `echo "***" | docker login` 제거
+      #    명시적 --config로 로그인(타임아웃 포함)
+      - name: Docker login (explicit --config)
+        timeout-minutes: 2
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          set -euxo pipefail
+          docker --config "$DOCKER_CONFIG" logout || true
+          printf '%s' "$DOCKER_PASSWORD" | docker --config "$DOCKER_CONFIG" login -u "$DOCKER_USERNAME" --password-stdin
+          sed 's/"auth":".*"/"auth":"***"/' "$DOCKER_CONFIG/config.json" || true
 
+      - name: Ensure compose files exist
+        run: |
+          set -euxo pipefail
+          ls -al "$DEPLOY_DIR"
+          test -f "$DEPLOY_DIR/docker-compose.yml"
+
+      # compose에도 동일한 --config 사용(일관성)
       - name: Pull images with compose
         working-directory: ${{ env.DEPLOY_DIR }}
-        run: docker compose pull
+        run: docker --config "$DOCKER_CONFIG" compose pull
         timeout-minutes: 10
 
       - name: Deploy with compose
         working-directory: ${{ env.DEPLOY_DIR }}
-        run: docker compose up -d
+        run: docker --config "$DOCKER_CONFIG" compose up -d
 
       - name: Check containers
-        run: docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
+        run: docker --config "$DOCKER_CONFIG" ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"


### PR DESCRIPTION
## 연관 이슈
#112 
## 작업 요약
macOS Keychain으로 인해 docker login 단계가 멈추던 문제를 해결하고, 배포 경로 하드코딩을 제거했으며, CD는 compose 기반 배포만 수행하도록 단순화했습니다.

## 작업 상세 설명
- Keychain 우회 적용. 잡 전용 DOCKER_CONFIG를 생성하고 credsStore를 비워 비인터랙티브 환경의 대기 문제를 제거
- docker 로그인 방식을 echo 파이프에서 docker --config 방식으로 교체. compose 포함 모든 docker 명령에 동일한 설정을 적용
- DEPLOY_DIR, DOCKER_CONFIG를 동적으로 해석하도록 스텝 추가. 레포 Variables가 없을 경우 HOME 기반 기본값 사용
- 데몬 및 컨텍스트 확인, Docker Hub 접근성 점검 스텝 추가로 실패 지점 가시성 강화
- CI에서 이미지 빌드·푸시 완료를 전제로 CD는 docker compose pull 후 up -d만 수행
- compose 실행 전 배포 디렉터리와 docker-compose.yml 존재 검증

## 기타
- 필수 시크릿: DOCKER_USERNAME, DOCKER_PASSWORD
- 선택 변수: DEPLOY_DIR, DOCKER_CONFIG. 미설정 시 기본값으로 동작
- 러너 라벨은 self-hosted, macOS, ARM64 조합 중 레포 설정과 일치해야 함