### PR TITLE
Macmini CD 워크플로우 안정화(키체인 우회, 경로 변수화, Compose 배포)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,16 +54,8 @@ jobs:
 
       # 기존의 `echo "***" | docker login` 제거
       #    명시적 --config로 로그인(타임아웃 포함)
-      - name: Docker login (explicit --config)
-        timeout-minutes: 2
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          set -euxo pipefail
-          docker --config "$DOCKER_CONFIG" logout || true
-          printf '%s' "$DOCKER_PASSWORD" | docker --config "$DOCKER_CONFIG" login -u "$DOCKER_USERNAME" --password-stdin
-          sed 's/"auth":".*"/"auth":"***"/' "$DOCKER_CONFIG/config.json" || true
+      - name: Docker login
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
       - name: Ensure compose files exist
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, macOS]  # 라벨에 맞춰 조정: [self-hosted], [self-hosted, macOS, ARM64] 등
+    runs-on: [self-hosted, macmini]
 
     steps:
       - name: Checkout
@@ -15,52 +15,71 @@ jobs:
 
       - name: Resolve dynamic paths (no hardcoding)
         run: |
-          # DEPLOY_DIR: repo variable 있으면 사용, 없으면 $HOME/Documents
           if [ -n "${{ vars.DEPLOY_DIR }}" ]; then
             echo "DEPLOY_DIR=${{ vars.DEPLOY_DIR }}" >> "$GITHUB_ENV"
           else
             echo "DEPLOY_DIR=$HOME/Documents" >> "$GITHUB_ENV"
           fi
-
-          # DOCKER_CONFIG: repo variable 있으면 사용, 없으면 $RUNNER_TEMP/.docker
           if [ -n "${{ vars.DOCKER_CONFIG }}" ]; then
             echo "DOCKER_CONFIG=${{ vars.DOCKER_CONFIG }}" >> "$GITHUB_ENV"
           else
             echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
           fi
 
-          echo "Using DEPLOY_DIR=$DEPLOY_DIR"
-          echo "Using DOCKER_CONFIG=$DOCKER_CONFIG"
-
-      - name: Quick daemon check
+      - name: Show resolved paths
         run: |
-          set -e
+          echo "DEPLOY_DIR=$DEPLOY_DIR"
+          echo "DOCKER_CONFIG=$DOCKER_CONFIG"
+
+      - name: Quick daemon & context check
+        run: |
+          set -euxo pipefail
           docker version
           docker info
+          docker context ls
 
-      - name: Disable macOS Keychain credsStore (per-job)
+      # Keychain 우회: 잡 전용 docker config 생성 + credsStore 비활성화
+      - name: Prepare per-job Docker config (bypass Keychain)
         run: |
+          set -euxo pipefail
           mkdir -p "$DOCKER_CONFIG"
-          echo '{"auths": {}, "credsStore": ""}' > "$DOCKER_CONFIG/config.json"
+          printf '%s\n' '{"auths": {}, "credsStore": ""}' > "$DOCKER_CONFIG/config.json"
+          cat "$DOCKER_CONFIG/config.json"
 
-      - name: Registry reachability sanity check
-        run: curl -sS https://registry-1.docker.io/v2/ || true
+      # 네트워크 확인(느리면 여기서 보임)
+      - name: Network sanity check to Docker Hub
+        run: |
+          set -euxo pipefail
+          curl -I --max-time 10 https://registry-1.docker.io/v2/ || true
 
-      - name: Docker login
-        uses: docker/login-action@v3
-        timeout-minutes: 3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # 기존의 `echo "***" | docker login` 제거
+      #    명시적 --config로 로그인(타임아웃 포함)
+      - name: Docker login (explicit --config)
+        timeout-minutes: 2
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          set -euxo pipefail
+          docker --config "$DOCKER_CONFIG" logout || true
+          printf '%s' "$DOCKER_PASSWORD" | docker --config "$DOCKER_CONFIG" login -u "$DOCKER_USERNAME" --password-stdin
+          sed 's/"auth":".*"/"auth":"***"/' "$DOCKER_CONFIG/config.json" || true
 
+      - name: Ensure compose files exist
+        run: |
+          set -euxo pipefail
+          ls -al "$DEPLOY_DIR"
+          test -f "$DEPLOY_DIR/docker-compose.yml"
+
+      # compose에도 동일한 --config 사용(일관성)
       - name: Pull images with compose
         working-directory: ${{ env.DEPLOY_DIR }}
-        run: docker compose pull
+        run: docker --config "$DOCKER_CONFIG" compose pull
         timeout-minutes: 10
 
       - name: Deploy with compose
         working-directory: ${{ env.DEPLOY_DIR }}
-        run: docker compose up -d
+        run: docker --config "$DOCKER_CONFIG" compose up -d
 
       - name: Check containers
-        run: docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
+        run: docker --config "$DOCKER_CONFIG" ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,12 +7,13 @@ on:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, macmini]
+    runs-on: [self-hosted, macOS]  # 필요시 [self-hosted, macOS, ARM64]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # 하드코딩 제거: 레포 Variables 사용, 없으면 기본값으로 설정
       - name: Resolve dynamic paths (no hardcoding)
         run: |
           if [ -n "${{ vars.DEPLOY_DIR }}" ]; then
@@ -20,50 +21,52 @@ jobs:
           else
             echo "DEPLOY_DIR=$HOME/Documents" >> "$GITHUB_ENV"
           fi
+          # DOCKER_CONFIG는 러너 임시 디렉터리 기본값 사용(키체인 우회용)
           if [ -n "${{ vars.DOCKER_CONFIG }}" ]; then
             echo "DOCKER_CONFIG=${{ vars.DOCKER_CONFIG }}" >> "$GITHUB_ENV"
           else
             echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
           fi
 
-      - name: Show resolved paths
-        run: |
-          echo "DEPLOY_DIR=$DEPLOY_DIR"
-          echo "DOCKER_CONFIG=$DOCKER_CONFIG"
-
       - name: Quick daemon & context check
         run: |
-          set -euxo pipefail
+          set -e
           docker version
           docker info
           docker context ls
 
-      # Keychain 우회: 잡 전용 docker config 생성 + credsStore 비활성화
+      # Keychain 우회: 잡 전용 Docker config 생성 후 credsStore 비활성화
       - name: Prepare per-job Docker config (bypass Keychain)
         run: |
-          set -euxo pipefail
+          set -e
           mkdir -p "$DOCKER_CONFIG"
-          printf '%s\n' '{"auths": {}, "credsStore": ""}' > "$DOCKER_CONFIG/config.json"
+          echo '{"auths": {}, "credsStore": ""}' > "$DOCKER_CONFIG/config.json"
+          echo "Using DOCKER_CONFIG=$DOCKER_CONFIG"
           cat "$DOCKER_CONFIG/config.json"
 
-      # 네트워크 확인(느리면 여기서 보임)
-      - name: Network sanity check to Docker Hub
-        run: |
-          set -euxo pipefail
-          curl -I --max-time 10 https://registry-1.docker.io/v2/ || true
+      # 네트워크/레지스트리 접근 미리 점검(지연 원인 가시화)
+      - name: Registry reachability sanity check
+        run: curl -I --max-time 10 https://registry-1.docker.io/v2/ || true
 
-      # 기존의 `echo "***" | docker login` 제거
-      #    명시적 --config로 로그인(타임아웃 포함)
+      # CI와 동일한 액션 사용하되, DOCKER_CONFIG를 명시적으로 전달
       - name: Docker login
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        uses: docker/login-action@v3
+        timeout-minutes: 3
+        env:
+          DOCKER_CONFIG: ${{ env.DOCKER_CONFIG }}
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # 배포 전 경로/파일 검증
       - name: Ensure compose files exist
         run: |
-          set -euxo pipefail
+          set -e
+          echo "DEPLOY_DIR=$DEPLOY_DIR"
           ls -al "$DEPLOY_DIR"
-          test -f "$DEPLOY_DIR/docker-compose.yml"
+          test -f "$DEPLOY_DIR/docker-compose.yml" || (echo "docker-compose.yml not found"; exit 1)
 
-      # compose에도 동일한 --config 사용(일관성)
+      # compose에도 동일한 DOCKER_CONFIG를 적용(일관성)
       - name: Pull images with compose
         working-directory: ${{ env.DEPLOY_DIR }}
         run: docker --config "$DOCKER_CONFIG" compose pull

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,26 +1,53 @@
-name: CD - Deploy on Macmini
+name: CI - Build and Push (no build-time secrets)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/story-field-be
 
 jobs:
-  deploy:
-    runs-on: [self-hosted, macOS]   # runner 라벨 맞추기
+  build-and-push:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Docker login
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-      - name: Deploy with Docker Compose
-        run: |
-          cd /Users/gyeongditor/Documents
-          docker compose pull
-          docker compose up -d
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
-      - name: Check containers
-        run: docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
+      - name: Build JAR (skip tests)
+        run: ./gradlew clean build -x test
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta (tags & labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=branch
+            type=sha
+
+      - name: Build & Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## 연관 이슈
#112 

## 작업 요약
macOS Keychain으로 인한 docker 로그인 지연을 해소하고, 배포 경로 하드코딩을 제거했습니다. CD는 compose 기반으로 pull 후 up -d만 수행합니다.

## 작업 상세 설명
- 잡 전용 DOCKER_CONFIG 생성 및 credsStore 비활성화로 Keychain 우회
- DEPLOY_DIR, DOCKER_CONFIG를 변수화하여 하드코딩 제거
- docker/login-action 적용 시 DOCKER_CONFIG 명시 전달
- compose 전용 배포 흐름 구성: docker compose pull → docker compose up -d
- 데몬 및 레지스트리 사전 점검 스텝 추가

## 기타
- 필수 시크릿: DOCKER_USERNAME, DOCKER_PASSWORD
- 필요 시 Repository Variables에 DEPLOY_DIR, DOCKER_CONFIG 등록 가능