### PR TITLE
merge to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,13 +13,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Resolve dynamic paths (no hardcoding)
+      - name: Resolve variables (no hardcoding)
         run: |
+          # DEPLOY_DIR: repo variables에 있으면 사용, 없으면 $HOME/Documents
           if [ -n "${{ vars.DEPLOY_DIR }}" ]; then
             echo "DEPLOY_DIR=${{ vars.DEPLOY_DIR }}" >> "$GITHUB_ENV"
           else
             echo "DEPLOY_DIR=$HOME/Documents" >> "$GITHUB_ENV"
           fi
+
+          # IMAGE_NAME / IMAGE_TAG: vars 없으면 기본값으로 결정
+          if [ -n "${{ vars.IMAGE_NAME }}" ]; then
+            echo "IMAGE_NAME=${{ vars.IMAGE_NAME }}" >> "$GITHUB_ENV"
+          else
+            echo "IMAGE_NAME=gyeongditor/story-field-be" >> "$GITHUB_ENV"
+          fi
+          if [ -n "${{ vars.IMAGE_TAG }}" ]; then
+            echo "IMAGE_TAG=${{ vars.IMAGE_TAG }}" >> "$GITHUB_ENV"
+          else
+            echo "IMAGE_TAG=latest" >> "$GITHUB_ENV"
+          fi
+
+          echo "IMAGE_REMOTE=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_ENV"
 
       - name: Quick daemon check
         run: |
@@ -34,12 +49,17 @@ jobs:
           ls -al "$DEPLOY_DIR"
           test -f "$DEPLOY_DIR/docker-compose.yml"
 
-      - name: Pull images with compose (no login; uses existing creds)
-        working-directory: ${{ env.DEPLOY_DIR }}
-        run: docker compose pull
-        timeout-minutes: 10
+      # compose pull 대신 앱 이미지 한 개만 pull
+      - name: Pre-pull app image only (linux/arm64)
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          unset HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy || true
+          echo "Pulling $IMAGE_REMOTE for linux/arm64"
+          docker pull --platform linux/arm64 "$IMAGE_REMOTE"
 
-      - name: Deploy with compose
+      # 새 이미지가 있으면 바로 교체
+      - name: Deploy with compose (no pull)
         working-directory: ${{ env.DEPLOY_DIR }}
         run: docker compose up -d
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,13 +7,12 @@ on:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, macOS]  # 필요시 [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, macOS]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # 하드코딩 제거: 레포 Variables 사용, 없으면 기본값으로 설정
       - name: Resolve dynamic paths (no hardcoding)
         run: |
           if [ -n "${{ vars.DEPLOY_DIR }}" ]; then
@@ -21,60 +20,28 @@ jobs:
           else
             echo "DEPLOY_DIR=$HOME/Documents" >> "$GITHUB_ENV"
           fi
-          # DOCKER_CONFIG는 러너 임시 디렉터리 기본값 사용(키체인 우회용)
-          if [ -n "${{ vars.DOCKER_CONFIG }}" ]; then
-            echo "DOCKER_CONFIG=${{ vars.DOCKER_CONFIG }}" >> "$GITHUB_ENV"
-          else
-            echo "DOCKER_CONFIG=$RUNNER_TEMP/.docker" >> "$GITHUB_ENV"
-          fi
 
-      - name: Quick daemon & context check
+      - name: Quick daemon check
         run: |
           set -e
           docker version
           docker info
-          docker context ls
 
-      # Keychain 우회: 잡 전용 Docker config 생성 후 credsStore 비활성화
-      - name: Prepare per-job Docker config (bypass Keychain)
-        run: |
-          set -e
-          mkdir -p "$DOCKER_CONFIG"
-          echo '{"auths": {}, "credsStore": ""}' > "$DOCKER_CONFIG/config.json"
-          echo "Using DOCKER_CONFIG=$DOCKER_CONFIG"
-          cat "$DOCKER_CONFIG/config.json"
-
-      # 네트워크/레지스트리 접근 미리 점검(지연 원인 가시화)
-      - name: Registry reachability sanity check
-        run: curl -I --max-time 10 https://registry-1.docker.io/v2/ || true
-
-      # CI와 동일한 액션 사용하되, DOCKER_CONFIG를 명시적으로 전달
-      - name: Docker login
-        uses: docker/login-action@v3
-        timeout-minutes: 3
-        env:
-          DOCKER_CONFIG: ${{ env.DOCKER_CONFIG }}
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      # 배포 전 경로/파일 검증
-      - name: Ensure compose files exist
+      - name: Ensure compose files
         run: |
           set -e
           echo "DEPLOY_DIR=$DEPLOY_DIR"
           ls -al "$DEPLOY_DIR"
-          test -f "$DEPLOY_DIR/docker-compose.yml" || (echo "docker-compose.yml not found"; exit 1)
+          test -f "$DEPLOY_DIR/docker-compose.yml"
 
-      # compose에도 동일한 DOCKER_CONFIG를 적용(일관성)
-      - name: Pull images with compose
+      - name: Pull images with compose (no login; uses existing creds)
         working-directory: ${{ env.DEPLOY_DIR }}
-        run: docker --config "$DOCKER_CONFIG" compose pull
+        run: docker compose pull
         timeout-minutes: 10
 
       - name: Deploy with compose
         working-directory: ${{ env.DEPLOY_DIR }}
-        run: docker --config "$DOCKER_CONFIG" compose up -d
+        run: docker compose up -d
 
       - name: Check containers
-        run: docker --config "$DOCKER_CONFIG" ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
+        run: docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -2,7 +2,7 @@ name: CI - Build and Push (no build-time secrets)
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "develop" ]
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/story-field-be


### PR DESCRIPTION
## 연관 이슈
#123

## 작업 요약
compose pull을 제거하고 앱 이미지(gyeongditor/story-field-be:latest)만 사전 pull 후 up -d로 배포하도록 단순화했습니다.

## 작업 상세 설명
- docker pull --platform linux/arm64로 앱 이미지 한 개만 선(先) 수신
- docker compose up -d로 서비스 교체(기존 DB/Redis는 유지)
- DEPLOY_DIR/IMAGE_NAME/IMAGE_TAG 변수화 및 기본값 제공

## 기타
- 필요 시 레포 Variables: DEPLOY_DIR, IMAGE_NAME, IMAGE_TAG
- 프록시 환경이면 pull 전에 HTTP(S)_PROXY 해제 로직 포함