### PR TITLE
Refactor: 이미지명 명세

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,14 +49,14 @@ jobs:
           ls -al "$DEPLOY_DIR"
           test -f "$DEPLOY_DIR/docker-compose.yml"
 
-      # compose pull 대신 앱 이미지 한 개만 pull
-      - name: Pre-pull app image only (linux/arm64)
+      # 여기서 고정 이미지로 직접 pull
+      - name: Pull app image (fixed ref)
         timeout-minutes: 5
         run: |
           set -euxo pipefail
+          # 프록시 환경이면 잠깐 해제(느림 방지)
           unset HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy || true
-          echo "Pulling $IMAGE_REMOTE for linux/arm64"
-          docker pull --platform linux/arm64 "$IMAGE_REMOTE"
+          docker pull --platform linux/arm64 gyeongditor/story-field-be:latest
 
       # 새 이미지가 있으면 바로 교체
       - name: Deploy with compose (no pull)


### PR DESCRIPTION
## 연관 이슈
#112 

## 작업 요약
compose pull을 제거하고, 앱 이미지(gyeongditor/story-field-be:latest)만 직접 pull 후 `docker compose up -d`로 배포하도록 단순화했습니다.

## 작업 상세 설명
- `docker pull --platform linux/arm64 gyeongditor/story-field-be:latest`로 이미지 선(先) 수신
- DB/Redis 등 기존 서비스는 변경 없이 유지
- DEPLOY_DIR는 Repository Variables 또는 `$HOME/Documents` 기본값 사용
- 프록시 환경 지연 대응: pull 직전 proxy env 일시 해제

## 기타
- CI에서 멀티 아키텍처 푸시 시 성능/호환성 향상
- 필요 시 IMAGE_TAG 변경으로 빠른 롤백 가능
