### PR TITLE
Refactor: 앱 이미지 직접 pull 후 배포

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,13 +50,26 @@ jobs:
           test -f "$DEPLOY_DIR/docker-compose.yml"
 
       # 여기서 고정 이미지로 직접 pull
-      - name: Pull app image (fixed ref)
+      - name:
+          Sanity: tiny image pull (quick network check)
+        timeout-minutes: 2
+        run: |
+          set -euxo pipefail
+          docker --debug pull --platform linux/arm64 alpine:3.20
+
+      - name: Pull app image (force docker.io prefix, retry, timeout)
         timeout-minutes: 5
         run: |
           set -euxo pipefail
-          # 프록시 환경이면 잠깐 해제(느림 방지)
-          unset HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy || true
-          docker pull --platform linux/arm64 gyeongditor/story-field-be:latest
+          img="docker.io/gyeongditor/story-field-be:latest"
+          echo "Pulling $img (linux/arm64)"
+          # 3회 재시도 (각 20s 타임아웃) — 어디서 끊기는지 로그 남김
+          for i in 1 2 3; do
+            (timeout 20s docker --debug pull --platform linux/arm64 "$img") && break || {
+              echo "retry #$i failed; sleeping..."
+              sleep 2
+            }
+          done
 
       # 새 이미지가 있으면 바로 교체
       - name: Deploy with compose (no pull)


### PR DESCRIPTION
## 연관 이슈
#112 

## 작업 요약
compose pull을 제거하고 앱 이미지(gyeongditor/story-field-be:latest)만 직접 pull한 뒤 `docker compose up -d`로 배포하도록 단순화했습니다.

## 작업 상세 설명
- `docker pull --platform linux/arm64 docker.io/gyeongditor/story-field-be:latest` 선(先) 수신
- compose는 pull 없이 up -d만 수행, DB/Redis 등 기존 리소스는 변경 없음
- DEPLOY_DIR 변수화로 경로 하드코딩 제거(없으면 $HOME/Documents 사용)

## 기타
- 네트워크 이슈 대비: 필요 시 tiny image 먼저 pull, timeout/재시도 옵션 활용 가능