### PR TITLE
141 req auth 모듈에 토큰 검증 apiverifytoken 추가

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/Controller/AuthController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/AuthController.java
@@ -32,4 +32,8 @@ public class AuthController implements AuthApi {
     public ApiResponseDTO<Map<String, String>> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
         return authService.reissueAccessToken(request, response);
     }
+    @Override
+    public ApiResponseDTO<Boolean> verifyToken(String authorizationHeader) {
+        return authService.verifyToken(authorizationHeader);
+    }
 }

--- a/src/main/java/com/gyeongditor/storyfield/response/SuccessCode.java
+++ b/src/main/java/com/gyeongditor/storyfield/response/SuccessCode.java
@@ -19,7 +19,8 @@ public enum SuccessCode {
     // 3. 인증/Auth
     AUTH_200_001(HttpStatus.OK, "AUTH_200_001", "로그인이 성공적으로 완료되었습니다."),
     AUTH_200_002(HttpStatus.OK, "AUTH_200_002", "로그아웃이 성공적으로 완료되었습니다."),
-    AUTH_200_007(HttpStatus.OK, "AUTH_200_003", "RT값으로 새로운 AT생성에 성공했습니다."),
+    AUTH_200_007(HttpStatus.OK, "AUTH_200_007", "RT값으로 새로운 AT생성에 성공했습니다."),
+    AUTH_200_008(HttpStatus.OK, "AUTH_200_008", "인가된 사용자 입니다."),
 
     // 4. 메일
     MAIL_200_001(HttpStatus.OK, "MAIL_200_001", "인증 메일이 성공적으로 전송되었습니다."),

--- a/src/main/java/com/gyeongditor/storyfield/service/AuthService.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/AuthService.java
@@ -17,4 +17,6 @@ public interface AuthService {
     ApiResponseDTO<Map<String, String>> reissueAccessToken(HttpServletRequest request, HttpServletResponse response);
 
     String extractAccessToken(HttpServletRequest request);
+
+    public ApiResponseDTO<Boolean> verifyToken(String authorizationHeader);
 }

--- a/src/main/java/com/gyeongditor/storyfield/swagger/api/AuthApi.java
+++ b/src/main/java/com/gyeongditor/storyfield/swagger/api/AuthApi.java
@@ -77,4 +77,21 @@ public interface AuthApi {
             HttpServletRequest request,
             HttpServletResponse response
     );
+
+    @Operation(
+            summary = "토큰 검증",
+            description = "AccessToken의 유효 여부를 Boolean 값으로 반환합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiSuccessResponse(
+            SuccessCode.AUTH_200_008 // 신규 SuccessCode 추가 필요
+    )
+    @ApiErrorResponse({
+            ErrorCode.AUTH_401_003, // 토큰 없음
+            ErrorCode.AUTH_401_004  // 토큰 유효하지 않음
+    })
+    @PostMapping("/verify")
+    ApiResponseDTO<Boolean> verifyToken(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader
+    );
 }


### PR DESCRIPTION
## 연관 이슈
> #141 

## 작업 요약
> 사용자 인증을 위한 토큰 검증 기능을 구현하였습니다.

## 작업 상세 설명
- 토큰 검증 API 추가
- 인가된 사용자 성공 코드 추가

## 기타
- 토큰 검증 실패 시 적절한 에러 응답이 반환됩니다.
- 추후 리프레시 토큰 관련 로직 추가가 필요할 수 있습니다.