### PR TITLE
143 req dev환경에서 swagger 접속 안되는 이슈해결

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/swagger/config/SwaggerConfig.java
+++ b/src/main/java/com/gyeongditor/storyfield/swagger/config/SwaggerConfig.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 @OpenAPIDefinition(servers = {
         @Server(url = "http://localhost:9080", description = "Local"),
+        @Server(url = "http://100.73.50.93/api", description = "Dev (Nginx Proxy)"),
         @Server(url = "https://api.storyfield.dev", description = "Prod")
 })
 @Configuration

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -99,3 +99,7 @@ spring.main.lazy-initialization=true
 
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=100MB
+
+# Swagger
+springdoc.swagger-ui.path=/api/swagger-ui
+springdoc.api-docs.path=/api/v3/api-docs


### PR DESCRIPTION
## 연관 이슈
> #143 

## 작업 요약
Dev 환경에서 Swagger UI 및 API 호출 경로를 Nginx 프록시(/api) 구조에 맞게 수정

## 작업 상세 설명
- SwaggerConfig 내 @OpenAPIDefinition에 Dev 서버 URL(http://100.73.50.93/api) 추가
- application.properties에 Swagger 문서 및 UI 경로 설정 추가
```
springdoc.swagger-ui.path=/api/swagger-ui
springdoc.api-docs.path=/api/v3/api-docs
```
- Dev 환경에서 http://100.73.50.93/api/swagger-ui/index.html#/ 접속 시 Swagger UI 정상 로드 및 “Try it out” 기능이 올바른 엔드포인트(/api/...)로 요청되도록 수정
- Nginx 프록시 기반 구조(80 → 9080)와 SpringDoc 내부 경로(/api) 일치화

## 기타
> 추가적으로 알아야 할 사항 설명
