### PR TITLE
Feat: Swagger 경로 화이트리스트 추가

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/config/SecurityConfig.java
+++ b/src/main/java/com/gyeongditor/storyfield/config/SecurityConfig.java
@@ -57,7 +57,9 @@ public class SecurityConfig {
                                 "/swagger-ui/index.html",
                                 "/v3/api-docs",
                                 "/v3/api-docs/**",
-                                "/stories/save").permitAll()
+                                "/stories/save",
+                                "/api/swagger-ui/**",
+                                "/api/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 연관 이슈
> #143 

## 작업 요약  
> Swagger UI가 `/login`으로 리다이렉트되는 문제 해결  
> SecurityConfig 내 Swagger 관련 경로 화이트리스트 추가  

## 작업 상세 설명  
> - Dev 환경에서 Swagger UI 경로(`/api/swagger-ui/**`) 및 문서 경로(`/api/v3/api-docs/**`)가 인증 필터에 걸려 `/login`으로 리다이렉트되는 문제 발생  
> - `SecurityConfig`의 `authorizeHttpRequests()` 설정에 다음 경로 추가  
>   ```java
>   "/api/swagger-ui/**",
>   "/api/v3/api-docs/**"
>   ```  
> - 기존 `/swagger-ui/**`, `/v3/api-docs/**` 경로는 유지하여 로컬 및 운영 환경 모두 호환되도록 구성  
> - 수정 후 Dev 환경(`http://100.73.50.93/api/swagger-ui/index.html#/`)에서 인증 없이 Swagger UI 정상 접근 확인  

## 기타  
> - Nginx 프록시 구조(`/api` prefix)로 인해 Swagger 리소스 경로를 `/api` 하위로 이동했으므로 해당 화이트리스트는 필수  
> - 추후 프로파일 분리를 통해 Dev 환경에서만 Swagger 허용하도록 개선 예정
