### PR TITLE
Fix: /api 프리픽스 제거

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/swagger/config/SwaggerConfig.java
+++ b/src/main/java/com/gyeongditor/storyfield/swagger/config/SwaggerConfig.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @OpenAPIDefinition(servers = {
         @Server(url = "http://localhost:9080", description = "Local"),
-        @Server(url = "http://100.73.50.93/api", description = "Dev (Nginx Proxy)"),
+        @Server(url = "http://100.73.50.93", description = "Dev (Nginx Proxy)"),
         @Server(url = "https://api.storyfield.dev", description = "Prod")
 })
 @Configuration

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -101,7 +101,9 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=100MB
 
 # Swagger
-springdoc.swagger-ui.path=/api/swagger-ui
-springdoc.api-docs.path=/api/v3/api-docs
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui/index.html
+springdoc.swagger-ui.config-url=/v3/api-docs/swagger-config
+
 # nginx??? ??(gzip)? ?? ??? Spring Boot? ?? ??? ?? ??? Spring Boot?? ????
 server.compression.enabled=false


### PR DESCRIPTION
## 연관 이슈
> #143

## 작업 요약
> Swagger UI 접근 경로를 `/swagger-ui` 루트 기반으로 변경하고 `/api` 프리픽스 제거

## 작업 상세 설명
> 
> - `SwaggerConfig` 내 `@OpenAPIDefinition`의 서버 URL 중 `Dev (Nginx Proxy)` 항목에서 `/api` 제거  
> - Swagger UI 및 OpenAPI Docs 접근 경로를 `application.properties`에 맞춰 `/swagger-ui` 및 `/v3/api-docs`로 통일  
> - 외부 접근 시 Swagger 리소스 누락(NoResourceFoundException) 문제 해결  
> - 프록시 구조(Nginx)와 경로 구조 일관성 유지

## 기타
> Swagger UI 접근 경로: `http://100.73.50.93/swagger-ui/index.html`
