### PR TITLE
Develop

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -101,9 +101,9 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=100MB
 
 # Swagger
-springdoc.api-docs.path=/v3/api-docs
-springdoc.swagger-ui.path=/swagger-ui/index.html
+springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.config-url=/v3/api-docs/swagger-config
+springdoc.api-docs.path=/v3/api-docs
 
 # nginx??? ??(gzip)? ?? ??? Spring Boot? ?? ??? ?? ??? Spring Boot?? ????
 server.compression.enabled=false


### PR DESCRIPTION
## 연관 이슈
> #143 
## 작업 요약
> Swagger UI 경로 중복 및 설정 충돌 문제 해결

## 작업 상세 설명
> - Swagger UI 접근 시 `/swagger-ui/swagger-ui/index.html`로 중복되는 문제 수정  
> - `application.properties`에서 `springdoc.swagger-ui.path`를 `/swagger-ui.html`로 변경  
> - `nginx.conf` 내 `/swagger-ui/` location 블록의 `proxy_pass` 경로를 `http://127.0.0.1:9080/`로 수정  
> - Swagger UI 리소스 정상 로드 및 “Failed to load remote configuration” 오류 제거 확인 예정
## 기타
> 추가적으로 알아야 할 사항 설명
