### PR TITLE
Fix: Swagger UI 기본 문서 경로 수정 및 Petstore 예시 제거

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -102,6 +102,7 @@ spring.servlet.multipart.max-request-size=100MB
 
 # Swagger
 springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.url=/v3/api-docs
 springdoc.swagger-ui.config-url=/v3/api-docs/swagger-config
 springdoc.api-docs.path=/v3/api-docs
 


### PR DESCRIPTION
## 연관 이슈
#143

## 작업 요약
Swagger UI 기본 문서 경로를 수정하여 Petstore 예시가 표시되는 문제를 해결했습니다.

## 작업 상세 설명
springdoc 설정에서 swagger-ui.url 및 config-url 경로를 /v3/api-docs 로 명시적으로 지정했습니다.  
기존 잘못된 상대경로로 인해 Swagger UI가 기본 Petstore API 문서를 불러오던 문제를 수정했습니다.  
이제 Swagger UI 접속 시 이야기밭 API 문서가 정상적으로 로드됩니다.

## 기타
추후 Nginx 프록시 환경에서도 동일한 경로(/swagger-ui.html, /v3/api-docs)로 접근 가능하도록 설정 검증 예정.
