### PR TITLE
156 refactor 동화 도메인 api를 restful 스타일로 재구성

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
@@ -6,12 +6,19 @@ import com.gyeongditor.storyfield.swagger.api.ImageApi;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class ImageController implements ImageApi {
 
     private final S3Service s3Service;
+
+    @Override
+    public ApiResponseDTO<List<String>> uploadImageFile(List<MultipartFile> files, HttpServletRequest request) {
+        return s3Service.uploadImageFile(files, request);
+    }
 
     @Override
     public ApiResponseDTO<String> getImageUrl(String fileName, HttpServletRequest request) {

--- a/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
+++ b/src/main/java/com/gyeongditor/storyfield/Controller/ImageController.java
@@ -1,6 +1,7 @@
 package com.gyeongditor.storyfield.Controller;
 
 import com.gyeongditor.storyfield.dto.ApiResponseDTO;
+import com.gyeongditor.storyfield.service.AuthService;
 import com.gyeongditor.storyfield.service.S3Service;
 import com.gyeongditor.storyfield.swagger.api.ImageApi;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,10 +15,17 @@ import java.util.List;
 public class ImageController implements ImageApi {
 
     private final S3Service s3Service;
+    private final AuthService authService;
 
     @Override
     public ApiResponseDTO<List<String>> uploadImageFile(List<MultipartFile> files, HttpServletRequest request) {
         return s3Service.uploadImageFile(files, request);
+    }
+
+    @Override
+    public ApiResponseDTO<String> getImagePresignedUrl(String fileName, HttpServletRequest request) {
+        String accessToken = authService.extractAccessToken(request);
+        return s3Service.generatePresignedUrl(fileName, accessToken);
     }
 
     @Override

--- a/src/main/java/com/gyeongditor/storyfield/config/CorsConfig.java
+++ b/src/main/java/com/gyeongditor/storyfield/config/CorsConfig.java
@@ -33,8 +33,8 @@ public class CorsConfig {
         config.setMaxAge(props.getMaxAge());
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        // RN 전용 엔드포인트에만 CORS 적용
-        source.registerCorsConfiguration("/api/**", config);
+        // 모든 엔드포인트에 CORS 적용 (FastAPI, React Native 등)
+        source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
     }
 

--- a/src/main/java/com/gyeongditor/storyfield/service/S3Service.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/S3Service.java
@@ -11,11 +11,7 @@ public interface S3Service {
 
     ApiResponseDTO<String> generatePresignedUrl(String fileName, String accessToken);
 
-    List<String> uploadFiles(List<MultipartFile> files, String accessToken) throws IOException;
-
     ApiResponseDTO<List<String>> uploadImageFile(List<MultipartFile> files, HttpServletRequest request);
-
-    String uploadThumbnailFile(MultipartFile file, String accessToken) throws IOException;
 
     ApiResponseDTO<String> uploadAudioFile(MultipartFile file, String accessToken);
 

--- a/src/main/java/com/gyeongditor/storyfield/service/S3Service.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/S3Service.java
@@ -13,6 +13,8 @@ public interface S3Service {
 
     List<String> uploadFiles(List<MultipartFile> files, String accessToken) throws IOException;
 
+    ApiResponseDTO<List<String>> uploadImageFile(List<MultipartFile> files, HttpServletRequest request);
+
     String uploadThumbnailFile(MultipartFile file, String accessToken) throws IOException;
 
     ApiResponseDTO<String> uploadAudioFile(MultipartFile file, String accessToken);

--- a/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
@@ -87,6 +87,40 @@ public class S3ServiceImpl implements S3Service {
     }
 
     @Override
+    public ApiResponseDTO<List<String>> uploadImageFile(List<MultipartFile> files, HttpServletRequest request) {
+        String accessToken = authService.extractAccessToken(request); // 이미 사용 중인 패턴
+        jwtTokenProvider.validateOrThrow(accessToken);
+
+        if (files == null || files.isEmpty()) {
+            throw new CustomException(ErrorCode.FILE_400_001);
+        }
+
+        List<String> keys = new ArrayList<>();
+        for (MultipartFile file : files) {
+            validateImageFile(file);
+            String key = "story-images/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+            try {
+                upload(file, key); // 기존 private upload 재사용. 내부에서 IOException을 래핑하거나 여기서 catch.
+                keys.add(key);
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.FILE_500_001);
+            }
+        }
+
+        return ApiResponseDTO.success(SuccessCode.FILE_200_001, keys);
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) throw new CustomException(ErrorCode.FILE_400_001);
+        if (file.getSize() > 10 * 1024 * 1024) throw new CustomException(ErrorCode.FILE_413_002);
+        String ct = file.getContentType();
+        String name = file.getOriginalFilename();
+        boolean okType = ct != null && (ct.equals("image/jpeg") || ct.equals("image/png") || ct.equals("image/webp"));
+        boolean okExt = name != null && name.toLowerCase().matches(".*\\.(jpg|jpeg|png|webp)$");
+        if (!okType && !okExt) throw new CustomException(ErrorCode.STORY_400_003);
+    }
+
+    @Override
     public String uploadThumbnailFile(MultipartFile file, String accessToken) throws IOException {
         jwtTokenProvider.validateOrThrow(accessToken);
 

--- a/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
@@ -23,11 +23,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.*;
+import java.util.zip.GZIPInputStream;
 
 @Service
 @RequiredArgsConstructor
@@ -71,24 +74,8 @@ public class S3ServiceImpl implements S3Service {
     }
 
     @Override
-    public List<String> uploadFiles(List<MultipartFile> files, String accessToken) throws IOException {
-        jwtTokenProvider.validateOrThrow(accessToken);
-
-        List<String> uploadedFileNames = new ArrayList<>();
-        for (MultipartFile file : files) {
-            if (file != null && !file.isEmpty()) {
-                String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-                upload(file, fileName);
-                uploadedFileNames.add(fileName);
-            }
-        }
-
-        return uploadedFileNames;
-    }
-
-    @Override
     public ApiResponseDTO<List<String>> uploadImageFile(List<MultipartFile> files, HttpServletRequest request) {
-        String accessToken = authService.extractAccessToken(request); // 이미 사용 중인 패턴
+        String accessToken = authService.extractAccessToken(request);
         jwtTokenProvider.validateOrThrow(accessToken);
 
         if (files == null || files.isEmpty()) {
@@ -98,9 +85,24 @@ public class S3ServiceImpl implements S3Service {
         List<String> keys = new ArrayList<>();
         for (MultipartFile file : files) {
             validateImageFile(file);
-            String key = UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+            String originalName = file.getOriginalFilename();
+            boolean isGzFile = originalName != null && originalName.toLowerCase().endsWith(".gz");
+
             try {
-                upload(file, key); // 기존 private upload 재사용. 내부에서 IOException을 래핑하거나 여기서 catch.
+                String key;
+                if (isGzFile) {
+                    // .gz 파일: 압축 해제 후 PNG로 업로드
+                    byte[] pngBytes = gunzipToBytes(file);
+                    String baseName = stripGzExtension(safeName(originalName));
+                    String pngName = ensurePngExtension(baseName);
+                    key = UUID.randomUUID() + "_" + pngName;
+                    uploadBytes(pngBytes, key, "image/png");
+                } else {
+                    // 일반 이미지: 그대로 업로드
+                    key = UUID.randomUUID() + "_" + originalName;
+                    upload(file, key);
+                }
                 keys.add(key);
             } catch (IOException e) {
                 throw new CustomException(ErrorCode.FILE_500_001);
@@ -115,21 +117,76 @@ public class S3ServiceImpl implements S3Service {
         if (file.getSize() > 10 * 1024 * 1024) throw new CustomException(ErrorCode.FILE_413_002);
         String ct = file.getContentType();
         String name = file.getOriginalFilename();
-        boolean okType = ct != null && (ct.equals("image/jpeg") || ct.equals("image/png") || ct.equals("image/webp"));
-        boolean okExt = name != null && name.toLowerCase().matches(".*\\.(jpg|jpeg|png|webp)$");
+
+        // .gz 파일은 압축된 이미지로 간주하여 허용
+        boolean isGzFile = name != null && name.toLowerCase().endsWith(".gz");
+
+        boolean okType = ct != null && (ct.equals("image/jpeg") || ct.equals("image/png") || ct.equals("image/webp") || ct.equals("application/gzip") || ct.equals("application/x-gzip"));
+        boolean okExt = name != null && name.toLowerCase().matches(".*\\.(jpg|jpeg|png|webp|gz)$");
+
         // Content-Type이나 확장자 중 하나라도 유효하지 않으면 예외 발생
         if (!(okType || okExt)) throw new CustomException(ErrorCode.STORY_400_003);
     }
 
-    @Override
-    public String uploadThumbnailFile(MultipartFile file, String accessToken) throws IOException {
-        jwtTokenProvider.validateOrThrow(accessToken);
+    private byte[] gunzipToBytes(MultipartFile gzFile) {
+        if (gzFile == null || gzFile.isEmpty()) {
+            throw new CustomException(ErrorCode.FILE_400_001, "빈 파일입니다");
+        }
 
-        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        // 파일 크기 체크 (10MB 제한)
+        if (gzFile.getSize() > 10 * 1024 * 1024) {
+            throw new CustomException(ErrorCode.FILE_413_002, "파일 크기가 너무 큽니다");
+        }
 
-        upload(file, fileName);
+        try (InputStream in = gzFile.getInputStream();
+             GZIPInputStream gzin = new GZIPInputStream(in);
+             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            gzin.transferTo(bos);
+            return bos.toByteArray();
+        } catch (IOException e) {
+            String fileName = safeName(gzFile.getOriginalFilename());
 
-        return fileName;
+            // GZIP 형식 오류
+            if (e.getMessage().contains("Not in GZIP format") ||
+                e.getMessage().contains("invalid header") ||
+                e.getMessage().contains("incorrect header check")) {
+                throw new CustomException(ErrorCode.STORY_400_002,
+                    "GZIP 압축 형식이 아닙니다: " + fileName);
+            }
+
+            // 파일 접근 권한 문제
+            if (e.getMessage().contains("Access denied") ||
+                e.getMessage().contains("Permission denied")) {
+                throw new CustomException(ErrorCode.STORY_500_004,
+                    "파일 접근 권한이 없습니다");
+            }
+
+            // 일반적인 GZIP 해제 실패
+            throw new CustomException(ErrorCode.STORY_400_002,
+                    "압축 파일 해제에 실패했습니다: " + fileName);
+        }
+    }
+
+    private static String safeName(final String name) {
+        if (name == null || name.isBlank()) {
+            return "file.png";
+        }
+        return Paths.get(name).getFileName().toString();
+    }
+
+    private static String stripGzExtension(final String name) {
+        if (name.toLowerCase(Locale.ROOT).endsWith(".gz")) {
+            return name.substring(0, name.length() - 3);
+        }
+        return name;
+    }
+
+    private static String ensurePngExtension(final String name) {
+        final String lower = name.toLowerCase(Locale.ROOT);
+        if (lower.endsWith(".png")) {
+            return name;
+        }
+        return name + ".png";
     }
 
     private void upload(MultipartFile file, String fileName) throws IOException {

--- a/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
@@ -117,7 +117,8 @@ public class S3ServiceImpl implements S3Service {
         String name = file.getOriginalFilename();
         boolean okType = ct != null && (ct.equals("image/jpeg") || ct.equals("image/png") || ct.equals("image/webp"));
         boolean okExt = name != null && name.toLowerCase().matches(".*\\.(jpg|jpeg|png|webp)$");
-        if (!okType && !okExt) throw new CustomException(ErrorCode.STORY_400_003);
+        // Content-Type이나 확장자 중 하나라도 유효하지 않으면 예외 발생
+        if (!(okType || okExt)) throw new CustomException(ErrorCode.STORY_400_003);
     }
 
     @Override
@@ -152,18 +153,9 @@ public class S3ServiceImpl implements S3Service {
 
         try {
             String fileName = "audio/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
-
-            ObjectMetadata metadata = new ObjectMetadata();
-            metadata.setContentLength(file.getSize());
-            metadata.setContentType(file.getContentType());
-
-            amazonS3.putObject(awsProperties.getBucket(), fileName, file.getInputStream(), metadata);
-
+            upload(file, fileName);
             return ApiResponseDTO.success(SuccessCode.AUDIO_200_001, getFileUrl(fileName));
-
         } catch (IOException e) {
-            throw new CustomException(ErrorCode.AUDIO_500_001);
-        } catch (Exception e) {
             throw new CustomException(ErrorCode.AUDIO_500_001);
         }
     }
@@ -277,7 +269,7 @@ public class S3ServiceImpl implements S3Service {
     }
 
     private void validateAudioFile(MultipartFile file) {
-        if (file.isEmpty()) {
+        if (file == null || file.isEmpty()) {
             throw new CustomException(ErrorCode.AUDIO_400_001);
         }
 
@@ -296,7 +288,8 @@ public class S3ServiceImpl implements S3Service {
         boolean validMimeType = contentType != null && ALLOWED_AUDIO_TYPES.contains(contentType);
         boolean validExtension = !fileExtension.isEmpty() && ALLOWED_AUDIO_EXTENSIONS.contains(fileExtension);
 
-        if (!validMimeType && !validExtension) {
+        // Content-Type이나 확장자 중 하나라도 유효하지 않으면 예외 발생
+        if (!(validMimeType || validExtension)) {
             throw new CustomException(ErrorCode.AUDIO_400_002);
         }
     }

--- a/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
@@ -98,7 +98,7 @@ public class S3ServiceImpl implements S3Service {
         List<String> keys = new ArrayList<>();
         for (MultipartFile file : files) {
             validateImageFile(file);
-            String key = "story-images/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+            String key = UUID.randomUUID() + "_" + file.getOriginalFilename();
             try {
                 upload(file, key); // 기존 private upload 재사용. 내부에서 IOException을 래핑하거나 여기서 catch.
                 keys.add(key);

--- a/src/main/java/com/gyeongditor/storyfield/swagger/api/ImageApi.java
+++ b/src/main/java/com/gyeongditor/storyfield/swagger/api/ImageApi.java
@@ -10,11 +10,37 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "Image", description = "이미지")
 @RequestMapping("/images")
 public interface ImageApi {
+
+    @Operation(
+            summary = "이미지 업로드",
+            description = "S3에 이미지를 업로드 합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiSuccessResponse(
+            SuccessCode.FILE_200_001
+    )
+    @ApiErrorResponse({
+            ErrorCode.AUTH_401_012, // 유효하지 않은 인증 토큰
+            ErrorCode.STORY_400_003, // 이미지 파일 형식이 올바르지 않습니다.
+            ErrorCode.FILE_400_001, // 파일이 비어있음.
+            ErrorCode.FILE_413_002 // 허용된 파일 크기 초과.
+    })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ApiResponseDTO<List<String>> uploadImageFile(
+            @Parameter(description = "업로드할 이미지 파일들", required = true)
+            @RequestPart("files") List<MultipartFile> files,
+            @Parameter(description = "Bearer AccessToken", required = true)
+            HttpServletRequest request
+    );
 
     @Operation(
             summary = "이미지 URL 조회",

--- a/src/main/java/com/gyeongditor/storyfield/swagger/api/ImageApi.java
+++ b/src/main/java/com/gyeongditor/storyfield/swagger/api/ImageApi.java
@@ -22,7 +22,7 @@ public interface ImageApi {
 
     @Operation(
             summary = "이미지 업로드",
-            description = "S3에 이미지를 업로드 합니다.",
+            description = "S3에 이미지를 업로드 합니다. .gz 압축 파일도 지원하며, 자동으로 압축 해제 후 PNG로 업로드됩니다.",
             security = {@SecurityRequirement(name = "bearerAuth")}
     )
     @ApiSuccessResponse(
@@ -31,8 +31,10 @@ public interface ImageApi {
     @ApiErrorResponse({
             ErrorCode.AUTH_401_012, // 유효하지 않은 인증 토큰
             ErrorCode.STORY_400_003, // 이미지 파일 형식이 올바르지 않습니다.
+            ErrorCode.STORY_400_002, // GZIP 압축 형식 오류
             ErrorCode.FILE_400_001, // 파일이 비어있음.
-            ErrorCode.FILE_413_002 // 허용된 파일 크기 초과.
+            ErrorCode.FILE_413_002, // 허용된 파일 크기 초과.
+            ErrorCode.FILE_500_001 // 파일 업로드 실패
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ApiResponseDTO<List<String>> uploadImageFile(
@@ -40,6 +42,23 @@ public interface ImageApi {
             @RequestPart("files") List<MultipartFile> files,
             @Parameter(description = "Bearer AccessToken", required = true)
             HttpServletRequest request
+    );
+
+    @Operation(
+            summary = "이미지 Presigned URL 조회",
+            description = "S3에 업로드된 파일명을 통해 임시 접근 가능한 Presigned URL을 반환합니다. (유효기간: 10분)",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiSuccessResponse(
+            SuccessCode.FILE_200_002
+    )
+    @ApiErrorResponse({
+            ErrorCode.AUTH_401_012 // 유효하지 않은 인증 토큰
+    })
+    @GetMapping("/presigned-url")
+    ApiResponseDTO<String> getImagePresignedUrl(
+            @Parameter(description = "S3에 저장된 파일명", required = true) @RequestParam String fileName,
+            @Parameter(description = "Bearer AccessToken", required = true) HttpServletRequest request
     );
 
     @Operation(
@@ -54,7 +73,7 @@ public interface ImageApi {
             ErrorCode.AUTH_401_012, // 유효하지 않은 인증 토큰
             ErrorCode.FILE_500_003  // 파일 URL 조회 실패
     })
-    @GetMapping("/{fileName}")
+    @GetMapping("/{fileName}/url")
     ApiResponseDTO<String> getImageUrl(
             @Parameter(description = "S3에 저장된 파일명", required = true) @PathVariable String fileName,
             @Parameter(description = "Bearer AccessToken", required = true) HttpServletRequest request

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -108,3 +108,11 @@ springdoc.api-docs.path=/v3/api-docs
 
 # nginx??? ??(gzip)? ?? ??? Spring Boot? ?? ??? ?? ??? Spring Boot?? ????
 server.compression.enabled=false
+
+# CORS (개발/배포 환경)
+# 환경변수로 필요한 Origin 지정 (기본값: localhost 개발 포트들)
+cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:8000,http://localhost:8081}
+cors.allowed-methods=GET,POST,PUT,PATCH,DELETE,OPTIONS
+cors.allowed-headers=*
+cors.exposed-headers=Authorization,Content-Disposition
+cors.max-age=3600


### PR DESCRIPTION
## 연관 이슈
  #156

  ## 작업 요약
  이미지 업로드 API에 .gz 압축 파일 지원 및 Presigned URL 생성 API 추가, S3Service 중복 메서드 제거

  ## 작업 상세 설명
  **1. 이미지 업로드 API .gz 파일 지원**
  - validateImageFile()에 .gz 확장자 및 application/gzip Content-Type 허용
  - .gz 파일 업로드 시 자동으로 압축 해제 후 PNG로 변환하여 S3에 업로드
  - gunzipToBytes() 메서드 추가로 GZIP 압축 해제 및 에러 핸들링

  **2. 이미지 Presigned URL 생성 API 추가**
  - GET /images/presigned-url?fileName={fileName} 엔드포인트 추가
  - S3 객체에 대한 임시 접근 URL 생성 (유효기간 10분)
  - Access Denied 문제 해결을 위한 안전한 이미지 조회 방법 제공

  **3. S3Service 중복 메서드 제거 및 리팩토링**
  - uploadFiles(), uploadThumbnailFile() 메서드 제거 (사용되지 않음)
  - uploadImageFile()로 통합하여 단일 책임 원칙 적용
  - 파일 검증 로직 개선 (De Morgan's Law 적용으로 가독성 향상)

  **4. 에러 코드 추가**
  - STORY_400_002: GZIP 압축 형식 오류
  - FILE_500_001: 파일 업로드 실패

  ## 기타
  - .gz 파일은 자동으로 압축 해제되어 UUID_{원본파일명}.png 형식으로 저장됨
  - Presigned URL은 Query Parameter 방식으로 파일명 전달
  - 서버 재시작 필요