### PR TITLE
Refactor: gunzipToBytes() 메서드 명시적 버퍼 읽기 방식으로 개선

### DIFF
--- a/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
+++ b/src/main/java/com/gyeongditor/storyfield/service/impl/S3ServiceImpl.java
@@ -138,30 +138,33 @@ public class S3ServiceImpl implements S3Service {
             throw new CustomException(ErrorCode.FILE_413_002, "파일 크기가 너무 큽니다");
         }
 
-        try (InputStream in = gzFile.getInputStream();
-             GZIPInputStream gzin = new GZIPInputStream(in);
-             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            gzin.transferTo(bos);
-            return bos.toByteArray();
+        try (GZIPInputStream gis = new GZIPInputStream(gzFile.getInputStream());
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[8192];
+            int len;
+            while ((len = gis.read(buffer)) != -1) {
+                baos.write(buffer, 0, len);
+            }
+            return baos.toByteArray();
         } catch (IOException e) {
             String fileName = safeName(gzFile.getOriginalFilename());
 
             // GZIP 형식 오류
-            if (e.getMessage().contains("Not in GZIP format") ||
+            if (e.getMessage() != null && (e.getMessage().contains("Not in GZIP format") ||
                 e.getMessage().contains("invalid header") ||
-                e.getMessage().contains("incorrect header check")) {
+                e.getMessage().contains("incorrect header check"))) {
                 throw new CustomException(ErrorCode.STORY_400_002,
                     "GZIP 압축 형식이 아닙니다: " + fileName);
             }
 
             // 파일 접근 권한 문제
-            if (e.getMessage().contains("Access denied") ||
-                e.getMessage().contains("Permission denied")) {
+            if (e.getMessage() != null && (e.getMessage().contains("Access denied") ||
+                e.getMessage().contains("Permission denied"))) {
                 throw new CustomException(ErrorCode.STORY_500_004,
                     "파일 접근 권한이 없습니다");
             }
 
-            // 일반적인 GZIP 해제 실패
+            // 일반적인 GZIP 해제 실패 (EOFException 등 포함)
             throw new CustomException(ErrorCode.STORY_400_002,
                     "압축 파일 해제에 실패했습니다: " + fileName);
         }


### PR DESCRIPTION
## 연관 이슈
  #156

  ## 작업 요약
  gunzipToBytes() 메서드 구현 완성 및 명시적 버퍼 읽기 방식으로 개선

  ## 작업 상세 설명
  **gunzipToBytes() 구현 개선**
  - transferTo() 대신 8KB 버퍼를 사용한 명시적 읽기/쓰기 방식으로 변경
  - try-with-resources로 GZIPInputStream 자동 닫기 처리
  - IOException, EOFException 등 모든 예외를 구체적으로 처리
  - NullPointerException 방지를 위한 e.getMessage() null 체크 추가

  **예외 처리 강화**
  - GZIP 형식 오류 감지 및 명확한 에러 메시지 제공
  - 파일 접근 권한 문제 구분 처리
  - 일반적인 압축 해제 실패 케이스 포괄 처리

  ## 기타
  - 코드 리뷰 피드백 반영 완료
